### PR TITLE
Fix GoReleaser v2 config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,8 @@ builds:
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    format: zip
+    formats:
+      - zip
     files:
       - terraform-registry-manifest.json
 
@@ -41,6 +42,8 @@ signs:
       - "--yes"
       - "--local-user"
       - "{{ .Env.GPG_FINGERPRINT }}"
+      - "--output"
+      - "${signature}"
       - "--detach-sign"
       - "--armor"
-      - "{{ .Artifact }}"
+      - "${artifact}"


### PR DESCRIPTION
## Summary
- update GoReleaser signing args to use shell-style placeholders
- switch archives format to formats list for v2 compatibility

## Testing
- go test ./...
- go vet ./...

## Issue
- #3