### PR TITLE
feat: add message match flags to tests

### DIFF
--- a/internal/client/tests.go
+++ b/internal/client/tests.go
@@ -37,8 +37,11 @@ type testUpdateRequest struct {
 }
 
 type messageContent struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role       string `json:"role"`
+	Content    string `json:"content"`
+	AnyRole    *bool  `json:"any_role,omitempty"`
+	AnyContent *bool  `json:"any_content,omitempty"`
+	Repeat     *bool  `json:"repeat,omitempty"`
 }
 
 type functionCallContent struct {
@@ -52,8 +55,19 @@ type functionCallOutputContent struct {
 	Output string `json:"output"`
 }
 
-func NewMessageItem(role, content string) (TestItem, error) {
-	payload, err := json.Marshal(messageContent{Role: role, Content: content})
+func NewMessageItem(role, content string, anyRole, anyContent, repeat *bool) (TestItem, error) {
+	messagePayload := messageContent{Role: role, Content: content}
+	if anyRole != nil && *anyRole {
+		messagePayload.AnyRole = anyRole
+	}
+	if anyContent != nil && *anyContent {
+		messagePayload.AnyContent = anyContent
+	}
+	if repeat != nil && *repeat {
+		messagePayload.Repeat = repeat
+	}
+
+	payload, err := json.Marshal(messagePayload)
 	if err != nil {
 		return TestItem{}, err
 	}
@@ -76,12 +90,19 @@ func NewFunctionCallOutputItem(callID, output string) (TestItem, error) {
 	return TestItem{Type: "function_call_output", Content: payload}, nil
 }
 
-func ParseMessageContent(item TestItem) (string, string, error) {
+func ParseMessageContent(item TestItem) (string, string, bool, bool, bool, error) {
 	var payload messageContent
 	if err := json.Unmarshal(item.Content, &payload); err != nil {
-		return "", "", err
+		return "", "", false, false, false, err
 	}
-	return payload.Role, payload.Content, nil
+	return payload.Role, payload.Content, boolFromPointer(payload.AnyRole), boolFromPointer(payload.AnyContent), boolFromPointer(payload.Repeat), nil
+}
+
+func boolFromPointer(value *bool) bool {
+	if value == nil {
+		return false
+	}
+	return *value
 }
 
 func ParseFunctionCallContent(item TestItem) (string, string, string, error) {

--- a/internal/client/tests.go
+++ b/internal/client/tests.go
@@ -44,6 +44,14 @@ type messageContent struct {
 	Repeat     *bool  `json:"repeat,omitempty"`
 }
 
+type MessageContent struct {
+	Role       string
+	Content    string
+	AnyRole    bool
+	AnyContent bool
+	Repeat     bool
+}
+
 type functionCallContent struct {
 	CallID    string `json:"call_id"`
 	Name      string `json:"name"`
@@ -90,12 +98,18 @@ func NewFunctionCallOutputItem(callID, output string) (TestItem, error) {
 	return TestItem{Type: "function_call_output", Content: payload}, nil
 }
 
-func ParseMessageContent(item TestItem) (string, string, bool, bool, bool, error) {
+func ParseMessageContent(item TestItem) (MessageContent, error) {
 	var payload messageContent
 	if err := json.Unmarshal(item.Content, &payload); err != nil {
-		return "", "", false, false, false, err
+		return MessageContent{}, err
 	}
-	return payload.Role, payload.Content, boolFromPointer(payload.AnyRole), boolFromPointer(payload.AnyContent), boolFromPointer(payload.Repeat), nil
+	return MessageContent{
+		Role:       payload.Role,
+		Content:    payload.Content,
+		AnyRole:    boolFromPointer(payload.AnyRole),
+		AnyContent: boolFromPointer(payload.AnyContent),
+		Repeat:     boolFromPointer(payload.Repeat),
+	}, nil
 }
 
 func boolFromPointer(value *bool) bool {

--- a/internal/provider/test_resource.go
+++ b/internal/provider/test_resource.go
@@ -487,18 +487,18 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 	for index, item := range items {
 		switch item.Type {
 		case "message":
-			role, content, anyRole, anyContent, repeat, err := client.ParseMessageContent(item)
+			messageContent, err := client.ParseMessageContent(item)
 			if err != nil {
 				diags.AddError("Error parsing message item", err.Error())
 				return nil, diags
 			}
 			flattened = append(flattened, testItemModel{
 				Type:       types.StringValue("message"),
-				Role:       types.StringValue(role),
-				Content:    types.StringValue(content),
-				AnyRole:    types.BoolValue(anyRole),
-				AnyContent: types.BoolValue(anyContent),
-				Repeat:     types.BoolValue(repeat),
+				Role:       types.StringValue(messageContent.Role),
+				Content:    types.StringValue(messageContent.Content),
+				AnyRole:    types.BoolValue(messageContent.AnyRole),
+				AnyContent: types.BoolValue(messageContent.AnyContent),
+				Repeat:     types.BoolValue(messageContent.Repeat),
 				CallID:     types.StringNull(),
 				FuncName:   types.StringNull(),
 				Arguments:  types.StringNull(),
@@ -514,9 +514,9 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 				Type:       types.StringValue("function_call"),
 				Role:       types.StringNull(),
 				Content:    types.StringNull(),
-				AnyRole:    types.BoolNull(),
-				AnyContent: types.BoolNull(),
-				Repeat:     types.BoolNull(),
+				AnyRole:    types.BoolValue(false),
+				AnyContent: types.BoolValue(false),
+				Repeat:     types.BoolValue(false),
 				CallID:     types.StringValue(callID),
 				FuncName:   types.StringValue(name),
 				Arguments:  types.StringValue(arguments),
@@ -532,9 +532,9 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 				Type:       types.StringValue("function_call_output"),
 				Role:       types.StringNull(),
 				Content:    types.StringNull(),
-				AnyRole:    types.BoolNull(),
-				AnyContent: types.BoolNull(),
-				Repeat:     types.BoolNull(),
+				AnyRole:    types.BoolValue(false),
+				AnyContent: types.BoolValue(false),
+				Repeat:     types.BoolValue(false),
 				CallID:     types.StringValue(callID),
 				FuncName:   types.StringNull(),
 				Arguments:  types.StringNull(),

--- a/internal/provider/test_resource.go
+++ b/internal/provider/test_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -41,19 +42,27 @@ type testResourceModel struct {
 }
 
 type testItemModel struct {
-	Type      types.String `tfsdk:"type"`
-	Role      types.String `tfsdk:"role"`
-	Content   types.String `tfsdk:"content"`
-	CallID    types.String `tfsdk:"call_id"`
-	FuncName  types.String `tfsdk:"func_name"`
-	Arguments types.String `tfsdk:"arguments"`
-	Output    types.String `tfsdk:"output"`
+	Type       types.String `tfsdk:"type"`
+	Role       types.String `tfsdk:"role"`
+	Content    types.String `tfsdk:"content"`
+	AnyRole    types.Bool   `tfsdk:"any_role"`
+	AnyContent types.Bool   `tfsdk:"any_content"`
+	Repeat     types.Bool   `tfsdk:"repeat"`
+	CallID     types.String `tfsdk:"call_id"`
+	FuncName   types.String `tfsdk:"func_name"`
+	Arguments  types.String `tfsdk:"arguments"`
+	Output     types.String `tfsdk:"output"`
 }
 
 type itemFieldRule struct {
 	Name     string
 	Getter   func(testItemModel) types.String
 	Required bool
+}
+
+type itemBoolFieldRule struct {
+	Name   string
+	Getter func(testItemModel) types.Bool
 }
 
 var testItemValidationRules = map[string][]itemFieldRule{
@@ -81,6 +90,12 @@ var testItemValidationRules = map[string][]itemFieldRule{
 		{Name: "func_name", Getter: func(item testItemModel) types.String { return item.FuncName }},
 		{Name: "arguments", Getter: func(item testItemModel) types.String { return item.Arguments }},
 	},
+}
+
+var testItemBoolValidationRules = []itemBoolFieldRule{
+	{Name: "any_role", Getter: func(item testItemModel) types.Bool { return item.AnyRole }},
+	{Name: "any_content", Getter: func(item testItemModel) types.Bool { return item.AnyContent }},
+	{Name: "repeat", Getter: func(item testItemModel) types.Bool { return item.Repeat }},
 }
 
 func NewTestResource() resource.Resource {
@@ -138,6 +153,21 @@ func (r *testResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 						},
 						"content": schema.StringAttribute{
 							Optional: true,
+						},
+						"any_role": schema.BoolAttribute{
+							Optional: true,
+							Computed: true,
+							Default:  booldefault.StaticBool(false),
+						},
+						"any_content": schema.BoolAttribute{
+							Optional: true,
+							Computed: true,
+							Default:  booldefault.StaticBool(false),
+						},
+						"repeat": schema.BoolAttribute{
+							Optional: true,
+							Computed: true,
+							Default:  booldefault.StaticBool(false),
 						},
 						"call_id": schema.StringAttribute{
 							Optional: true,
@@ -205,6 +235,24 @@ func (r *testResource) ValidateConfig(ctx context.Context, req resource.Validate
 				continue
 			}
 			validateUnexpectedString(&resp.Diagnostics, value, attrPath, itemType)
+		}
+
+		for _, rule := range testItemBoolValidationRules {
+			attrPath := itemPath.AtName(rule.Name)
+			value := rule.Getter(item)
+			if value.IsUnknown() || value.IsNull() || !value.ValueBool() {
+				continue
+			}
+			if itemType != "message" {
+				resp.Diagnostics.AddAttributeError(attrPath, "Unexpected item attribute", fmt.Sprintf("%s must not be true when type is %q.", attrPath.String(), itemType))
+				continue
+			}
+			if item.Role.IsUnknown() || item.Role.IsNull() {
+				continue
+			}
+			if item.Role.ValueString() == "assistant" {
+				resp.Diagnostics.AddAttributeError(attrPath, "Unexpected item attribute", fmt.Sprintf("%s must not be true when type is %q and role is %q.", attrPath.String(), itemType, item.Role.ValueString()))
+			}
 		}
 	}
 }
@@ -373,6 +421,14 @@ func validateUnexpectedString(diags *diag.Diagnostics, value types.String, attrP
 	diags.AddAttributeError(attrPath, "Unexpected item attribute", fmt.Sprintf("%s must not be set when type is %q.", attrPath.String(), itemType))
 }
 
+func boolPointerFromValue(value types.Bool) *bool {
+	if value.IsUnknown() || value.IsNull() || !value.ValueBool() {
+		return nil
+	}
+	boolValue := true
+	return &boolValue
+}
+
 func expandTestItems(items []testItemModel) ([]client.TestItem, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	if len(items) == 0 {
@@ -389,7 +445,10 @@ func expandTestItems(items []testItemModel) ([]client.TestItem, diag.Diagnostics
 		itemType := item.Type.ValueString()
 		switch itemType {
 		case "message":
-			messageItem, err := client.NewMessageItem(item.Role.ValueString(), item.Content.ValueString())
+			anyRole := boolPointerFromValue(item.AnyRole)
+			anyContent := boolPointerFromValue(item.AnyContent)
+			repeat := boolPointerFromValue(item.Repeat)
+			messageItem, err := client.NewMessageItem(item.Role.ValueString(), item.Content.ValueString(), anyRole, anyContent, repeat)
 			if err != nil {
 				diags.AddError("Error building message item", err.Error())
 				return nil, diags
@@ -428,19 +487,22 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 	for index, item := range items {
 		switch item.Type {
 		case "message":
-			role, content, err := client.ParseMessageContent(item)
+			role, content, anyRole, anyContent, repeat, err := client.ParseMessageContent(item)
 			if err != nil {
 				diags.AddError("Error parsing message item", err.Error())
 				return nil, diags
 			}
 			flattened = append(flattened, testItemModel{
-				Type:      types.StringValue("message"),
-				Role:      types.StringValue(role),
-				Content:   types.StringValue(content),
-				CallID:    types.StringNull(),
-				FuncName:  types.StringNull(),
-				Arguments: types.StringNull(),
-				Output:    types.StringNull(),
+				Type:       types.StringValue("message"),
+				Role:       types.StringValue(role),
+				Content:    types.StringValue(content),
+				AnyRole:    types.BoolValue(anyRole),
+				AnyContent: types.BoolValue(anyContent),
+				Repeat:     types.BoolValue(repeat),
+				CallID:     types.StringNull(),
+				FuncName:   types.StringNull(),
+				Arguments:  types.StringNull(),
+				Output:     types.StringNull(),
 			})
 		case "function_call":
 			callID, name, arguments, err := client.ParseFunctionCallContent(item)
@@ -449,13 +511,16 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 				return nil, diags
 			}
 			flattened = append(flattened, testItemModel{
-				Type:      types.StringValue("function_call"),
-				Role:      types.StringNull(),
-				Content:   types.StringNull(),
-				CallID:    types.StringValue(callID),
-				FuncName:  types.StringValue(name),
-				Arguments: types.StringValue(arguments),
-				Output:    types.StringNull(),
+				Type:       types.StringValue("function_call"),
+				Role:       types.StringNull(),
+				Content:    types.StringNull(),
+				AnyRole:    types.BoolNull(),
+				AnyContent: types.BoolNull(),
+				Repeat:     types.BoolNull(),
+				CallID:     types.StringValue(callID),
+				FuncName:   types.StringValue(name),
+				Arguments:  types.StringValue(arguments),
+				Output:     types.StringNull(),
 			})
 		case "function_call_output":
 			callID, output, err := client.ParseFunctionCallOutputContent(item)
@@ -464,13 +529,16 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 				return nil, diags
 			}
 			flattened = append(flattened, testItemModel{
-				Type:      types.StringValue("function_call_output"),
-				Role:      types.StringNull(),
-				Content:   types.StringNull(),
-				CallID:    types.StringValue(callID),
-				FuncName:  types.StringNull(),
-				Arguments: types.StringNull(),
-				Output:    types.StringValue(output),
+				Type:       types.StringValue("function_call_output"),
+				Role:       types.StringNull(),
+				Content:    types.StringNull(),
+				AnyRole:    types.BoolNull(),
+				AnyContent: types.BoolNull(),
+				Repeat:     types.BoolNull(),
+				CallID:     types.StringValue(callID),
+				FuncName:   types.StringNull(),
+				Arguments:  types.StringNull(),
+				Output:     types.StringValue(output),
 			})
 		default:
 			diags.AddAttributeError(path.Root("items").AtListIndex(index).AtName("type"), "Invalid item type", fmt.Sprintf("Unsupported item type %q.", item.Type))

--- a/internal/provider/test_resource_test.go
+++ b/internal/provider/test_resource_test.go
@@ -107,6 +107,46 @@ func TestAccTestResource_functionCallItems(t *testing.T) {
 	})
 }
 
+func TestAccTestResource_messageFlags(t *testing.T) {
+	orgName := acctest.RandomWithPrefix("tf-org")
+	orgSlug := acctest.RandomWithPrefix("tf-org")
+	suiteName := acctest.RandomWithPrefix("tf-suite")
+	testName := acctest.RandomWithPrefix("tf-test")
+
+	items := `[
+  {
+    type        = "message"
+    role        = "user"
+    content     = "Say hello"
+    any_role    = true
+    any_content = true
+    repeat      = true
+  }
+]`
+
+	config := testAccTestResourceConfig(orgName, orgSlug, suiteName, testName, "", items)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("testllm_test.test", "items.0.any_role", "true"),
+					resource.TestCheckResourceAttr("testllm_test.test", "items.0.any_content", "true"),
+					resource.TestCheckResourceAttr("testllm_test.test", "items.0.repeat", "true"),
+				),
+			},
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestAccTestResource_validateConfig(t *testing.T) {
 	orgName := acctest.RandomWithPrefix("tf-org")
 	orgSlug := acctest.RandomWithPrefix("tf-org")

--- a/internal/provider/test_resource_test.go
+++ b/internal/provider/test_resource_test.go
@@ -137,6 +137,17 @@ func TestAccTestResource_validateConfig(t *testing.T) {
   }
 ]`
 
+	invalidBoolItems := `[
+  {
+		type        = "message"
+		role        = "assistant"
+		content     = "Hello"
+		any_role    = true
+		any_content = true
+		repeat      = true
+  }
+]`
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -152,6 +163,10 @@ func TestAccTestResource_validateConfig(t *testing.T) {
 			{
 				Config:      testAccTestResourceConfig(orgName, orgSlug, suiteName, testName, "", invalidTypeItems),
 				ExpectError: regexp.MustCompile("type"),
+			},
+			{
+				Config:      testAccTestResourceConfig(orgName, orgSlug, suiteName, testName, "", invalidBoolItems),
+				ExpectError: regexp.MustCompile("any_role"),
 			},
 		},
 	})


### PR DESCRIPTION
## Summary
- add match flag fields to message payloads and parsing
- extend test resource schema/validation/expand/flatten for new flags
- add validation coverage for message flag constraints

## Testing
- go build ./...
- go vet ./...
- go test ./...

Closes #7