### PR TITLE
feat: add org data source and docs

### DIFF
--- a/docs/data-sources/organization.md
+++ b/docs/data-sources/organization.md
@@ -1,0 +1,32 @@
+---
+page_title: "testllm_organization Data Source"
+description: "Look up TestLLM organizations by slug."
+---
+
+# testllm_organization Data Source
+
+## Example Usage
+
+```hcl
+data "testllm_organization" "example" {
+  slug = "acme-corp"
+}
+
+resource "testllm_test_suite" "example" {
+  org_id = data.testllm_organization.example.id
+  name   = "Smoke Tests"
+}
+```
+
+## Schema
+
+### Required
+
+- `slug` (String) The unique slug of the organization to look up.
+
+### Read-Only
+
+- `id` (String) Unique identifier for the organization.
+- `name` (String) Display name for the organization.
+- `created_at` (String) Timestamp when the organization was created.
+- `updated_at` (String) Timestamp when the organization was last updated.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,40 @@
+---
+page_title: "TestLLM Provider"
+description: "Manage TestLLM organizations, test suites, and tests."
+---
+
+# TestLLM Provider
+
+The TestLLM provider manages TestLLM organizations, test suites, and tests.
+
+## Example Usage
+
+```hcl
+terraform {
+  required_providers {
+    testllm = {
+      source = "agynio/testllm"
+    }
+  }
+}
+
+provider "testllm" {
+  token = var.testllm_token
+}
+```
+
+## Authentication
+
+TestLLM supports two token types:
+
+- `tlp_` personal access tokens for user-level access.
+- `tlo_` organization tokens scoped to a specific organization.
+
+## Schema
+
+### Optional
+
+- `host` (String) TestLLM API base URL. Defaults to `https://testllm.dev`.
+- `token` (String, Sensitive) API authentication token.
+
+You can also set `TESTLLM_HOST` and `TESTLLM_TOKEN` environment variables to configure the provider.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,4 +37,4 @@ TestLLM supports two token types:
 - `host` (String) TestLLM API base URL. Defaults to `https://testllm.dev`.
 - `token` (String, Sensitive) API authentication token.
 
-You can also set `TESTLLM_HOST` and `TESTLLM_TOKEN` environment variables to configure the provider.
+~> **Note:** You can also set `TESTLLM_HOST` and `TESTLLM_TOKEN` environment variables to configure the provider.

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -1,0 +1,34 @@
+---
+page_title: "testllm_organization Resource"
+description: "Manage TestLLM organizations."
+---
+
+# testllm_organization Resource
+
+## Example Usage
+
+```hcl
+resource "testllm_organization" "example" {
+  name = "Acme Corp"
+  slug = "acme-corp"
+}
+```
+
+## Schema
+
+### Required
+
+- `name` (String) Display name for the organization.
+- `slug` (String) Unique slug for the organization.
+
+### Read-Only
+
+- `id` (String) Unique identifier for the organization.
+- `created_at` (String) Timestamp when the organization was created.
+- `updated_at` (String) Timestamp when the organization was last updated.
+
+## Import
+
+```sh
+terraform import testllm_organization.example <org-id>
+```

--- a/docs/resources/test.md
+++ b/docs/resources/test.md
@@ -1,0 +1,89 @@
+---
+page_title: "testllm_test Resource"
+description: "Manage TestLLM tests."
+---
+
+# testllm_test Resource
+
+## Example Usage
+
+```hcl
+resource "testllm_organization" "example" {
+  name = "Acme Corp"
+  slug = "acme-corp"
+}
+
+resource "testllm_test_suite" "example" {
+  org_id = testllm_organization.example.id
+  name   = "Smoke Tests"
+}
+
+resource "testllm_test" "example" {
+  org_id      = testllm_organization.example.id
+  suite_id    = testllm_test_suite.example.id
+  name        = "greeting-flow"
+  description = "Validate messages and tool calls"
+
+  items = [
+    {
+      type    = "message"
+      role    = "user"
+      content = "Say hello"
+    },
+    {
+      type      = "function_call"
+      call_id   = "call-1"
+      func_name = "lookup_user"
+      arguments = jsonencode({ id = "123" })
+    },
+    {
+      type    = "function_call_output"
+      call_id = "call-1"
+      output  = "ok"
+    },
+  ]
+}
+```
+
+## Schema
+
+### Required
+
+- `org_id` (String) Organization ID that owns the test.
+- `suite_id` (String) Test suite ID that owns the test.
+- `name` (String) Display name for the test.
+- `items` (List of Object) Ordered list of test items that define the test flow.
+
+### Optional
+
+- `description` (String) Description of the test.
+
+### Read-Only
+
+- `id` (String) Unique identifier for the test.
+- `created_at` (String) Timestamp when the test was created.
+- `updated_at` (String) Timestamp when the test was last updated.
+
+### Nested Schema for `items`
+
+Required:
+
+- `type` (String) Item type. One of `message`, `function_call`, or `function_call_output`.
+
+Optional:
+
+- `role` (String) Role for message items (`user`, `system`, `developer`, `assistant`).
+- `content` (String) Content for message items.
+- `any_role` (Bool) Whether any role is accepted for message items.
+- `any_content` (Bool) Whether any content is accepted for message items.
+- `repeat` (Bool) Whether the message item can repeat.
+- `call_id` (String) Function call identifier for `function_call` and `function_call_output` items.
+- `func_name` (String) Function name for `function_call` items.
+- `arguments` (String) JSON-encoded arguments for `function_call` items.
+- `output` (String) Output content for `function_call_output` items.
+
+## Import
+
+```sh
+terraform import testllm_test.example <org-id>/<suite-id>/<test-id>
+```

--- a/docs/resources/test_suite.md
+++ b/docs/resources/test_suite.md
@@ -1,0 +1,44 @@
+---
+page_title: "testllm_test_suite Resource"
+description: "Manage TestLLM test suites."
+---
+
+# testllm_test_suite Resource
+
+## Example Usage
+
+```hcl
+resource "testllm_organization" "example" {
+  name = "Acme Corp"
+  slug = "acme-corp"
+}
+
+resource "testllm_test_suite" "example" {
+  org_id      = testllm_organization.example.id
+  name        = "Smoke Tests"
+  description = "Basic sanity checks"
+}
+```
+
+## Schema
+
+### Required
+
+- `org_id` (String) Organization ID that owns the test suite.
+- `name` (String) Display name for the test suite.
+
+### Optional
+
+- `description` (String) Description of the test suite.
+
+### Read-Only
+
+- `id` (String) Unique identifier for the test suite.
+- `created_at` (String) Timestamp when the test suite was created.
+- `updated_at` (String) Timestamp when the test suite was last updated.
+
+## Import
+
+```sh
+terraform import testllm_test_suite.example <org-id>/<suite-id>
+```

--- a/examples/data-sources/testllm_organization/data-source.tf
+++ b/examples/data-sources/testllm_organization/data-source.tf
@@ -1,0 +1,8 @@
+data "testllm_organization" "example" {
+  slug = "acme-corp"
+}
+
+resource "testllm_test_suite" "example" {
+  org_id = data.testllm_organization.example.id
+  name   = "Smoke Tests"
+}

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -11,6 +11,5 @@ variable "testllm_token" {
 }
 
 provider "testllm" {
-  host  = "https://testllm.example.com"
   token = var.testllm_token
 }

--- a/examples/resources/testllm_organization/import.sh
+++ b/examples/resources/testllm_organization/import.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+terraform import testllm_organization.example <org-id>

--- a/examples/resources/testllm_test/import.sh
+++ b/examples/resources/testllm_test/import.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+terraform import testllm_test.example <org-id>/<suite-id>/<test-id>

--- a/examples/resources/testllm_test_suite/import.sh
+++ b/examples/resources/testllm_test_suite/import.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+terraform import testllm_test_suite.example <org-id>/<suite-id>

--- a/internal/client/organizations.go
+++ b/internal/client/organizations.go
@@ -45,6 +45,14 @@ func (c *Client) GetOrganization(ctx context.Context, orgID string) (*Organizati
 	return &response, nil
 }
 
+func (c *Client) ListOrganizations(ctx context.Context) ([]Organization, error) {
+	var response []Organization
+	if err := c.doRequest(ctx, http.MethodGet, "/api/orgs", nil, &response); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
 func (c *Client) UpdateOrganization(ctx context.Context, orgID, name string) (*Organization, error) {
 	request := organizationUpdateRequest{
 		Name: name,

--- a/internal/provider/organization_data_source.go
+++ b/internal/provider/organization_data_source.go
@@ -1,0 +1,130 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/agynio/terraform-provider-testllm/internal/client"
+)
+
+type organizationDataSource struct {
+	client *client.Client
+}
+
+type organizationDataSourceModel struct {
+	ID        types.String `tfsdk:"id"`
+	Name      types.String `tfsdk:"name"`
+	Slug      types.String `tfsdk:"slug"`
+	CreatedAt types.String `tfsdk:"created_at"`
+	UpdatedAt types.String `tfsdk:"updated_at"`
+}
+
+var _ datasource.DataSource = &organizationDataSource{}
+
+func NewOrganizationDataSource() datasource.DataSource {
+	return &organizationDataSource{}
+}
+
+func (d *organizationDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_organization"
+}
+
+func (d *organizationDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"slug": schema.StringAttribute{
+				Description: "The unique slug of the organization to look up.",
+				Required:    true,
+			},
+			"id": schema.StringAttribute{
+				Description: "Unique identifier for the organization.",
+				Computed:    true,
+			},
+			"name": schema.StringAttribute{
+				Description: "Display name for the organization.",
+				Computed:    true,
+			},
+			"created_at": schema.StringAttribute{
+				Description: "Timestamp when the organization was created.",
+				Computed:    true,
+			},
+			"updated_at": schema.StringAttribute{
+				Description: "Timestamp when the organization was last updated.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *organizationDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	clientInstance, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = clientInstance
+}
+
+func (d *organizationDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config organizationDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if config.Slug.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("slug"),
+			"Unknown organization slug",
+			"The provider cannot look up the organization because the slug value is unknown.",
+		)
+		return
+	}
+	if config.Slug.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("slug"),
+			"Missing organization slug",
+			"The provider cannot look up the organization because the slug value is missing.",
+		)
+		return
+	}
+
+	organizations, err := d.client.ListOrganizations(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error listing organizations", err.Error())
+		return
+	}
+
+	var matched *client.Organization
+	for index := range organizations {
+		if organizations[index].Slug == config.Slug.ValueString() {
+			matched = &organizations[index]
+			break
+		}
+	}
+	if matched == nil {
+		resp.Diagnostics.AddError(
+			"Organization not found",
+			fmt.Sprintf("No organization found with slug %q.", config.Slug.ValueString()),
+		)
+		return
+	}
+
+	state := organizationDataSourceModel{
+		ID:        types.StringValue(matched.ID),
+		Name:      types.StringValue(matched.Name),
+		Slug:      types.StringValue(matched.Slug),
+		CreatedAt: types.StringValue(matched.CreatedAt),
+		UpdatedAt: types.StringValue(matched.UpdatedAt),
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}

--- a/internal/provider/organization_data_source.go
+++ b/internal/provider/organization_data_source.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/agynio/terraform-provider-testllm/internal/client"
@@ -77,23 +76,6 @@ func (d *organizationDataSource) Read(ctx context.Context, req datasource.ReadRe
 	var config organizationDataSourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	if config.Slug.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("slug"),
-			"Unknown organization slug",
-			"The provider cannot look up the organization because the slug value is unknown.",
-		)
-		return
-	}
-	if config.Slug.IsNull() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("slug"),
-			"Missing organization slug",
-			"The provider cannot look up the organization because the slug value is missing.",
-		)
 		return
 	}
 

--- a/internal/provider/organization_data_source_test.go
+++ b/internal/provider/organization_data_source_test.go
@@ -1,0 +1,72 @@
+package provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccOrganizationDataSource_basic(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-org")
+	slug := acctest.RandomWithPrefix("tf-org")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOrganizationDataSourceConfig(name, slug),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("data.testllm_organization.test", "id", "testllm_organization.test", "id"),
+					resource.TestCheckResourceAttrPair("data.testllm_organization.test", "name", "testllm_organization.test", "name"),
+					resource.TestCheckResourceAttrPair("data.testllm_organization.test", "slug", "testllm_organization.test", "slug"),
+					resource.TestCheckResourceAttrSet("data.testllm_organization.test", "created_at"),
+					resource.TestCheckResourceAttrSet("data.testllm_organization.test", "updated_at"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOrganizationDataSource_notFound(t *testing.T) {
+	slug := acctest.RandomWithPrefix("tf-org-missing")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccOrganizationDataSourceNotFoundConfig(slug),
+				ExpectError: regexp.MustCompile("Organization not found"),
+			},
+		},
+	})
+}
+
+func testAccOrganizationDataSourceConfig(name, slug string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "testllm_organization" "test" {
+  name = %q
+  slug = %q
+}
+
+data "testllm_organization" "test" {
+  slug = testllm_organization.test.slug
+}
+`, testAccProviderConfig(), name, slug)
+}
+
+func testAccOrganizationDataSourceNotFoundConfig(slug string) string {
+	return fmt.Sprintf(`
+%s
+
+data "testllm_organization" "test" {
+  slug = %q
+}
+`, testAccProviderConfig(), slug)
+}

--- a/internal/provider/organization_resource.go
+++ b/internal/provider/organization_resource.go
@@ -42,28 +42,33 @@ func (r *organizationResource) Schema(_ context.Context, _ resource.SchemaReques
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Computed: true,
+				Description: "Unique identifier for the organization.",
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"name": schema.StringAttribute{
-				Required: true,
+				Description: "Display name for the organization.",
+				Required:    true,
 			},
 			"slug": schema.StringAttribute{
-				Required: true,
+				Description: "Unique slug for the organization.",
+				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"created_at": schema.StringAttribute{
-				Computed: true,
+				Description: "Timestamp when the organization was created.",
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"updated_at": schema.StringAttribute{
-				Computed: true,
+				Description: "Timestamp when the organization was last updated.",
+				Computed:    true,
 			},
 		},
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -38,11 +38,13 @@ func (p *testllmProvider) Schema(_ context.Context, _ provider.SchemaRequest, re
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"host": schema.StringAttribute{
-				Optional: true,
+				Description: "TestLLM API base URL. Defaults to https://testllm.dev. May also be set via the TESTLLM_HOST environment variable.",
+				Optional:    true,
 			},
 			"token": schema.StringAttribute{
-				Optional:  true,
-				Sensitive: true,
+				Description: "API authentication token. May also be set via the TESTLLM_TOKEN environment variable.",
+				Optional:    true,
+				Sensitive:   true,
 			},
 		},
 	}
@@ -76,19 +78,13 @@ func (p *testllmProvider) Configure(ctx context.Context, req provider.ConfigureR
 	if host == "" {
 		host = os.Getenv("TESTLLM_HOST")
 	}
+	if host == "" {
+		host = "https://testllm.dev"
+	}
 
 	token := config.Token.ValueString()
 	if token == "" {
 		token = os.Getenv("TESTLLM_TOKEN")
-	}
-
-	if host == "" {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("host"),
-			"Missing TestLLM host",
-			"The provider cannot create the TestLLM client because the host value is missing. Set the host in configuration or via TESTLLM_HOST.",
-		)
-		return
 	}
 	if token == "" {
 		resp.Diagnostics.AddAttributeError(
@@ -123,5 +119,7 @@ func (p *testllmProvider) Resources(_ context.Context) []func() resource.Resourc
 }
 
 func (p *testllmProvider) DataSources(_ context.Context) []func() datasource.DataSource {
-	return nil
+	return []func() datasource.DataSource{
+		NewOrganizationDataSource,
+	}
 }

--- a/internal/provider/test_resource.go
+++ b/internal/provider/test_resource.go
@@ -110,88 +110,106 @@ func (r *testResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Computed: true,
+				Description: "Unique identifier for the test.",
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"org_id": schema.StringAttribute{
-				Required: true,
+				Description: "Organization ID that owns the test.",
+				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"suite_id": schema.StringAttribute{
-				Required: true,
+				Description: "Test suite ID that owns the test.",
+				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"name": schema.StringAttribute{
-				Required: true,
+				Description: "Display name for the test.",
+				Required:    true,
 			},
 			"description": schema.StringAttribute{
-				Optional: true,
-				Computed: true,
-				Default:  stringdefault.StaticString(""),
+				Description: "Description of the test.",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 			},
 			"items": schema.ListNestedAttribute{
-				Required: true,
+				Description: "Ordered list of test items that define the test flow.",
+				Required:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"type": schema.StringAttribute{
-							Required: true,
+							Description: "Item type. One of message, function_call, or function_call_output.",
+							Required:    true,
 							Validators: []validator.String{
 								stringvalidator.OneOf("message", "function_call", "function_call_output"),
 							},
 						},
 						"role": schema.StringAttribute{
-							Optional: true,
+							Description: "Role for message items (user, system, developer, assistant).",
+							Optional:    true,
 							Validators: []validator.String{
 								stringvalidator.OneOf("user", "system", "developer", "assistant"),
 							},
 						},
 						"content": schema.StringAttribute{
-							Optional: true,
+							Description: "Content for message items.",
+							Optional:    true,
 						},
 						"any_role": schema.BoolAttribute{
-							Optional: true,
-							Computed: true,
-							Default:  booldefault.StaticBool(false),
+							Description: "Whether any role is accepted for message items.",
+							Optional:    true,
+							Computed:    true,
+							Default:     booldefault.StaticBool(false),
 						},
 						"any_content": schema.BoolAttribute{
-							Optional: true,
-							Computed: true,
-							Default:  booldefault.StaticBool(false),
+							Description: "Whether any content is accepted for message items.",
+							Optional:    true,
+							Computed:    true,
+							Default:     booldefault.StaticBool(false),
 						},
 						"repeat": schema.BoolAttribute{
-							Optional: true,
-							Computed: true,
-							Default:  booldefault.StaticBool(false),
+							Description: "Whether the message item can repeat.",
+							Optional:    true,
+							Computed:    true,
+							Default:     booldefault.StaticBool(false),
 						},
 						"call_id": schema.StringAttribute{
-							Optional: true,
+							Description: "Function call identifier for function_call and function_call_output items.",
+							Optional:    true,
 						},
 						"func_name": schema.StringAttribute{
-							Optional: true,
+							Description: "Function name for function_call items.",
+							Optional:    true,
 						},
 						"arguments": schema.StringAttribute{
-							Optional: true,
+							Description: "JSON-encoded arguments for function_call items.",
+							Optional:    true,
 						},
 						"output": schema.StringAttribute{
-							Optional: true,
+							Description: "Output content for function_call_output items.",
+							Optional:    true,
 						},
 					},
 				},
 			},
 			"created_at": schema.StringAttribute{
-				Computed: true,
+				Description: "Timestamp when the test was created.",
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"updated_at": schema.StringAttribute{
-				Computed: true,
+				Description: "Timestamp when the test was last updated.",
+				Computed:    true,
 			},
 		},
 	}

--- a/internal/provider/test_suite_resource.go
+++ b/internal/provider/test_suite_resource.go
@@ -46,33 +46,39 @@ func (r *testSuiteResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Computed: true,
+				Description: "Unique identifier for the test suite.",
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"org_id": schema.StringAttribute{
-				Required: true,
+				Description: "Organization ID that owns the test suite.",
+				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"name": schema.StringAttribute{
-				Required: true,
+				Description: "Display name for the test suite.",
+				Required:    true,
 			},
 			"description": schema.StringAttribute{
-				Optional: true,
-				Computed: true,
-				Default:  stringdefault.StaticString(""),
+				Description: "Description of the test suite.",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 			},
 			"created_at": schema.StringAttribute{
-				Computed: true,
+				Description: "Timestamp when the test suite was created.",
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"updated_at": schema.StringAttribute{
-				Computed: true,
+				Description: "Timestamp when the test suite was last updated.",
+				Computed:    true,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- add default host fallback and schema descriptions
- add organization data source support and client list call
- add registry docs and examples for resources and data sources

## Testing
- go build ./...
- go vet ./...
- go test ./...

Closes #9