### PR TITLE
Add Anthropic protocol support

### DIFF
--- a/docs/resources/test.md
+++ b/docs/resources/test.md
@@ -45,6 +45,44 @@ resource "testllm_test" "example" {
 }
 ```
 
+## Anthropic Example Usage
+
+```hcl
+resource "testllm_organization" "example" {
+  name = "Acme Corp"
+  slug = "acme-corp"
+}
+
+resource "testllm_test_suite" "anthropic" {
+  org_id   = testllm_organization.example.id
+  name     = "Anthropic Tests"
+  protocol = "anthropic"
+}
+
+resource "testllm_test" "anthropic" {
+  org_id   = testllm_organization.example.id
+  suite_id = testllm_test_suite.anthropic.id
+  name     = "anthropic-flow"
+
+  items = [
+    {
+      type = "anthropic_system"
+      text = "You are a helpful assistant."
+    },
+    {
+      type    = "anthropic_message"
+      role    = "user"
+      content = "Hello"
+    },
+    {
+      type           = "anthropic_message"
+      role           = "assistant"
+      content_blocks = jsonencode([{ type = "text", text = "Hi!" }])
+    },
+  ]
+}
+```
+
 ## Schema
 
 ### Required
@@ -68,12 +106,14 @@ resource "testllm_test" "example" {
 
 Required:
 
-- `type` (String) Item type. One of `message`, `function_call`, or `function_call_output`.
+- `type` (String) Item type. One of `message`, `function_call`, `function_call_output`, `anthropic_system`, or `anthropic_message`.
 
 Optional:
 
-- `role` (String) Role for message items (`user`, `system`, `developer`, `assistant`).
+- `role` (String) Role for message and anthropic_message items (`user`, `system`, `developer`, `assistant`).
 - `content` (String) Content for message items.
+- `text` (String) Text content for `anthropic_system` items.
+- `content_blocks` (String) JSON-encoded array of Anthropic content blocks.
 - `any_role` (Bool) Whether any role is accepted for message items.
 - `any_content` (Bool) Whether any content is accepted for message items.
 - `repeat` (Bool) Whether the message item can repeat.

--- a/docs/resources/test_suite.md
+++ b/docs/resources/test_suite.md
@@ -30,6 +30,7 @@ resource "testllm_test_suite" "example" {
 ### Optional
 
 - `description` (String) Description of the test suite.
+- `protocol` (String) Protocol used by tests in the suite. Defaults to `openai`.
 
 ### Read-Only
 

--- a/examples/resources/testllm_test/resource.tf
+++ b/examples/resources/testllm_test/resource.tf
@@ -9,6 +9,12 @@ resource "testllm_test_suite" "example" {
   description = "Basic sanity checks"
 }
 
+resource "testllm_test_suite" "anthropic" {
+  org_id   = testllm_organization.example.id
+  name     = "Anthropic Tests"
+  protocol = "anthropic"
+}
+
 resource "testllm_test" "example" {
   org_id   = testllm_organization.example.id
   suite_id = testllm_test_suite.example.id
@@ -24,6 +30,29 @@ resource "testllm_test" "example" {
       type    = "message"
       role    = "assistant"
       content = "Hello! How can I help you?"
+    },
+  ]
+}
+
+resource "testllm_test" "anthropic" {
+  org_id   = testllm_organization.example.id
+  suite_id = testllm_test_suite.anthropic.id
+  name     = "anthropic-flow"
+
+  items = [
+    {
+      type = "anthropic_system"
+      text = "You are a helpful assistant."
+    },
+    {
+      type    = "anthropic_message"
+      role    = "user"
+      content = "Hello"
+    },
+    {
+      type           = "anthropic_message"
+      role           = "assistant"
+      content_blocks = jsonencode([{ type = "text", text = "Hi there!" }])
     },
   ]
 }

--- a/examples/resources/testllm_test_suite/resource.tf
+++ b/examples/resources/testllm_test_suite/resource.tf
@@ -8,3 +8,9 @@ resource "testllm_test_suite" "example" {
   name        = "Smoke Tests"
   description = "Basic sanity checks"
 }
+
+resource "testllm_test_suite" "anthropic" {
+  org_id   = testllm_organization.example.id
+  name     = "Anthropic Tests"
+  protocol = "anthropic"
+}

--- a/internal/client/test_suites.go
+++ b/internal/client/test_suites.go
@@ -12,6 +12,7 @@ type TestSuite struct {
 	OrgID       string `json:"org_id"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
+	Protocol    string `json:"protocol"`
 	CreatedAt   string `json:"created_at"`
 	UpdatedAt   string `json:"updated_at"`
 }
@@ -19,6 +20,7 @@ type TestSuite struct {
 type testSuiteCreateRequest struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
+	Protocol    string `json:"protocol,omitempty"`
 }
 
 type testSuiteUpdateRequest struct {
@@ -26,10 +28,11 @@ type testSuiteUpdateRequest struct {
 	Description string `json:"description"`
 }
 
-func (c *Client) CreateTestSuite(ctx context.Context, orgID, name, description string) (*TestSuite, error) {
+func (c *Client) CreateTestSuite(ctx context.Context, orgID, name, description, protocol string) (*TestSuite, error) {
 	request := testSuiteCreateRequest{
 		Name:        name,
 		Description: description,
+		Protocol:    protocol,
 	}
 	var response TestSuite
 	path := fmt.Sprintf("/api/orgs/%s/suites", orgID)

--- a/internal/client/tests.go
+++ b/internal/client/tests.go
@@ -52,6 +52,30 @@ type MessageContent struct {
 	Repeat     bool
 }
 
+type anthropicSystemTextContent struct {
+	Text string `json:"text"`
+}
+
+type anthropicSystemBlocksContent struct {
+	Blocks json.RawMessage `json:"blocks"`
+}
+
+type AnthropicSystemContent struct {
+	Text   string
+	Blocks json.RawMessage
+}
+
+type anthropicMessageContent struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}
+
+type AnthropicMessageContent struct {
+	Role          string
+	Content       string
+	ContentBlocks json.RawMessage
+}
+
 type functionCallContent struct {
 	CallID    string `json:"call_id"`
 	Name      string `json:"name"`
@@ -98,6 +122,42 @@ func NewFunctionCallOutputItem(callID, output string) (TestItem, error) {
 	return TestItem{Type: "function_call_output", Content: payload}, nil
 }
 
+func NewAnthropicSystemTextItem(text string) (TestItem, error) {
+	payload, err := json.Marshal(anthropicSystemTextContent{Text: text})
+	if err != nil {
+		return TestItem{}, err
+	}
+	return TestItem{Type: "anthropic_system", Content: payload}, nil
+}
+
+func NewAnthropicSystemBlocksItem(blocksJSON json.RawMessage) (TestItem, error) {
+	payload, err := json.Marshal(anthropicSystemBlocksContent{Blocks: blocksJSON})
+	if err != nil {
+		return TestItem{}, err
+	}
+	return TestItem{Type: "anthropic_system", Content: payload}, nil
+}
+
+func NewAnthropicMessageStringItem(role, content string) (TestItem, error) {
+	contentPayload, err := json.Marshal(content)
+	if err != nil {
+		return TestItem{}, err
+	}
+	payload, err := json.Marshal(anthropicMessageContent{Role: role, Content: json.RawMessage(contentPayload)})
+	if err != nil {
+		return TestItem{}, err
+	}
+	return TestItem{Type: "anthropic_message", Content: payload}, nil
+}
+
+func NewAnthropicMessageBlocksItem(role string, blocksJSON json.RawMessage) (TestItem, error) {
+	payload, err := json.Marshal(anthropicMessageContent{Role: role, Content: blocksJSON})
+	if err != nil {
+		return TestItem{}, err
+	}
+	return TestItem{Type: "anthropic_message", Content: payload}, nil
+}
+
 func ParseMessageContent(item TestItem) (MessageContent, error) {
 	var payload messageContent
 	if err := json.Unmarshal(item.Content, &payload); err != nil {
@@ -133,6 +193,45 @@ func ParseFunctionCallOutputContent(item TestItem) (string, string, error) {
 		return "", "", err
 	}
 	return payload.CallID, payload.Output, nil
+}
+
+func ParseAnthropicSystemContent(item TestItem) (AnthropicSystemContent, error) {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(item.Content, &payload); err != nil {
+		return AnthropicSystemContent{}, err
+	}
+	textPayload, hasText := payload["text"]
+	blocksPayload, hasBlocks := payload["blocks"]
+	if hasText && hasBlocks {
+		return AnthropicSystemContent{}, fmt.Errorf("anthropic_system content must include either text or blocks")
+	}
+	if hasText {
+		var text string
+		if err := json.Unmarshal(textPayload, &text); err != nil {
+			return AnthropicSystemContent{}, err
+		}
+		return AnthropicSystemContent{Text: text}, nil
+	}
+	if hasBlocks {
+		return AnthropicSystemContent{Blocks: blocksPayload}, nil
+	}
+	return AnthropicSystemContent{}, fmt.Errorf("anthropic_system content missing text or blocks")
+}
+
+func ParseAnthropicMessageContent(item TestItem) (AnthropicMessageContent, error) {
+	var payload anthropicMessageContent
+	if err := json.Unmarshal(item.Content, &payload); err != nil {
+		return AnthropicMessageContent{}, err
+	}
+	var textContent string
+	if err := json.Unmarshal(payload.Content, &textContent); err == nil {
+		return AnthropicMessageContent{Role: payload.Role, Content: textContent}, nil
+	}
+	var blocks []json.RawMessage
+	if err := json.Unmarshal(payload.Content, &blocks); err != nil {
+		return AnthropicMessageContent{}, err
+	}
+	return AnthropicMessageContent{Role: payload.Role, ContentBlocks: payload.Content}, nil
 }
 
 func (c *Client) CreateTest(ctx context.Context, orgID, suiteID, name, description string, items []TestItem) (*Test, error) {

--- a/internal/client/tests.go
+++ b/internal/client/tests.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -223,15 +224,28 @@ func ParseAnthropicMessageContent(item TestItem) (AnthropicMessageContent, error
 	if err := json.Unmarshal(item.Content, &payload); err != nil {
 		return AnthropicMessageContent{}, err
 	}
-	var textContent string
-	if err := json.Unmarshal(payload.Content, &textContent); err == nil {
+
+	trimmed := bytes.TrimLeft(payload.Content, " \t\r\n")
+	if len(trimmed) == 0 {
+		return AnthropicMessageContent{}, fmt.Errorf("anthropic_message content must be a JSON string or array")
+	}
+
+	switch trimmed[0] {
+	case '"':
+		var textContent string
+		if err := json.Unmarshal(payload.Content, &textContent); err != nil {
+			return AnthropicMessageContent{}, fmt.Errorf("anthropic_message string content: %w", err)
+		}
 		return AnthropicMessageContent{Role: payload.Role, Content: textContent}, nil
+	case '[':
+		var blocks []json.RawMessage
+		if err := json.Unmarshal(payload.Content, &blocks); err != nil {
+			return AnthropicMessageContent{}, fmt.Errorf("anthropic_message content must be a JSON string or array: %w", err)
+		}
+		return AnthropicMessageContent{Role: payload.Role, ContentBlocks: payload.Content}, nil
+	default:
+		return AnthropicMessageContent{}, fmt.Errorf("anthropic_message content must be a JSON string or array")
 	}
-	var blocks []json.RawMessage
-	if err := json.Unmarshal(payload.Content, &blocks); err != nil {
-		return AnthropicMessageContent{}, err
-	}
-	return AnthropicMessageContent{Role: payload.Role, ContentBlocks: payload.Content}, nil
 }
 
 func (c *Client) CreateTest(ctx context.Context, orgID, suiteID, name, description string, items []TestItem) (*Test, error) {

--- a/internal/provider/test_resource.go
+++ b/internal/provider/test_resource.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -42,16 +43,18 @@ type testResourceModel struct {
 }
 
 type testItemModel struct {
-	Type       types.String `tfsdk:"type"`
-	Role       types.String `tfsdk:"role"`
-	Content    types.String `tfsdk:"content"`
-	AnyRole    types.Bool   `tfsdk:"any_role"`
-	AnyContent types.Bool   `tfsdk:"any_content"`
-	Repeat     types.Bool   `tfsdk:"repeat"`
-	CallID     types.String `tfsdk:"call_id"`
-	FuncName   types.String `tfsdk:"func_name"`
-	Arguments  types.String `tfsdk:"arguments"`
-	Output     types.String `tfsdk:"output"`
+	Type          types.String `tfsdk:"type"`
+	Role          types.String `tfsdk:"role"`
+	Content       types.String `tfsdk:"content"`
+	Text          types.String `tfsdk:"text"`
+	ContentBlocks types.String `tfsdk:"content_blocks"`
+	AnyRole       types.Bool   `tfsdk:"any_role"`
+	AnyContent    types.Bool   `tfsdk:"any_content"`
+	Repeat        types.Bool   `tfsdk:"repeat"`
+	CallID        types.String `tfsdk:"call_id"`
+	FuncName      types.String `tfsdk:"func_name"`
+	Arguments     types.String `tfsdk:"arguments"`
+	Output        types.String `tfsdk:"output"`
 }
 
 type itemFieldRule struct {
@@ -73,6 +76,8 @@ var testItemValidationRules = map[string][]itemFieldRule{
 		{Name: "func_name", Getter: func(item testItemModel) types.String { return item.FuncName }},
 		{Name: "arguments", Getter: func(item testItemModel) types.String { return item.Arguments }},
 		{Name: "output", Getter: func(item testItemModel) types.String { return item.Output }},
+		{Name: "text", Getter: func(item testItemModel) types.String { return item.Text }},
+		{Name: "content_blocks", Getter: func(item testItemModel) types.String { return item.ContentBlocks }},
 	},
 	"function_call": {
 		{Name: "call_id", Getter: func(item testItemModel) types.String { return item.CallID }, Required: true},
@@ -81,6 +86,8 @@ var testItemValidationRules = map[string][]itemFieldRule{
 		{Name: "role", Getter: func(item testItemModel) types.String { return item.Role }},
 		{Name: "content", Getter: func(item testItemModel) types.String { return item.Content }},
 		{Name: "output", Getter: func(item testItemModel) types.String { return item.Output }},
+		{Name: "text", Getter: func(item testItemModel) types.String { return item.Text }},
+		{Name: "content_blocks", Getter: func(item testItemModel) types.String { return item.ContentBlocks }},
 	},
 	"function_call_output": {
 		{Name: "call_id", Getter: func(item testItemModel) types.String { return item.CallID }, Required: true},
@@ -89,6 +96,24 @@ var testItemValidationRules = map[string][]itemFieldRule{
 		{Name: "content", Getter: func(item testItemModel) types.String { return item.Content }},
 		{Name: "func_name", Getter: func(item testItemModel) types.String { return item.FuncName }},
 		{Name: "arguments", Getter: func(item testItemModel) types.String { return item.Arguments }},
+		{Name: "text", Getter: func(item testItemModel) types.String { return item.Text }},
+		{Name: "content_blocks", Getter: func(item testItemModel) types.String { return item.ContentBlocks }},
+	},
+	"anthropic_system": {
+		{Name: "role", Getter: func(item testItemModel) types.String { return item.Role }},
+		{Name: "content", Getter: func(item testItemModel) types.String { return item.Content }},
+		{Name: "call_id", Getter: func(item testItemModel) types.String { return item.CallID }},
+		{Name: "func_name", Getter: func(item testItemModel) types.String { return item.FuncName }},
+		{Name: "arguments", Getter: func(item testItemModel) types.String { return item.Arguments }},
+		{Name: "output", Getter: func(item testItemModel) types.String { return item.Output }},
+	},
+	"anthropic_message": {
+		{Name: "role", Getter: func(item testItemModel) types.String { return item.Role }, Required: true},
+		{Name: "text", Getter: func(item testItemModel) types.String { return item.Text }},
+		{Name: "call_id", Getter: func(item testItemModel) types.String { return item.CallID }},
+		{Name: "func_name", Getter: func(item testItemModel) types.String { return item.FuncName }},
+		{Name: "arguments", Getter: func(item testItemModel) types.String { return item.Arguments }},
+		{Name: "output", Getter: func(item testItemModel) types.String { return item.Output }},
 	},
 }
 
@@ -146,14 +171,14 @@ func (r *testResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"type": schema.StringAttribute{
-							Description: "Item type. One of message, function_call, or function_call_output.",
+							Description: "Item type. One of message, function_call, function_call_output, anthropic_system, or anthropic_message.",
 							Required:    true,
 							Validators: []validator.String{
-								stringvalidator.OneOf("message", "function_call", "function_call_output"),
+								stringvalidator.OneOf("message", "function_call", "function_call_output", "anthropic_system", "anthropic_message"),
 							},
 						},
 						"role": schema.StringAttribute{
-							Description: "Role for message items (user, system, developer, assistant).",
+							Description: "Role for message and anthropic_message items (user, system, developer, assistant).",
 							Optional:    true,
 							Validators: []validator.String{
 								stringvalidator.OneOf("user", "system", "developer", "assistant"),
@@ -161,6 +186,14 @@ func (r *testResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 						},
 						"content": schema.StringAttribute{
 							Description: "Content for message items.",
+							Optional:    true,
+						},
+						"text": schema.StringAttribute{
+							Description: "Text content for anthropic_system items.",
+							Optional:    true,
+						},
+						"content_blocks": schema.StringAttribute{
+							Description: "JSON-encoded array of Anthropic content blocks.",
 							Optional:    true,
 						},
 						"any_role": schema.BoolAttribute{
@@ -271,6 +304,45 @@ func (r *testResource) ValidateConfig(ctx context.Context, req resource.Validate
 			if item.Role.ValueString() == "assistant" {
 				resp.Diagnostics.AddAttributeError(attrPath, "Unexpected item attribute", fmt.Sprintf("%s must not be true when type is %q and role is %q.", attrPath.String(), itemType, item.Role.ValueString()))
 			}
+		}
+
+		switch itemType {
+		case "anthropic_system":
+			if !item.Text.IsUnknown() && !item.ContentBlocks.IsUnknown() {
+				textSet := !item.Text.IsNull()
+				blocksSet := !item.ContentBlocks.IsNull()
+				if textSet == blocksSet {
+					resp.Diagnostics.AddAttributeError(
+						itemPath.AtName("text"),
+						"Invalid item attributes",
+						fmt.Sprintf("Exactly one of %s or %s must be set when type is %q.", itemPath.AtName("text").String(), itemPath.AtName("content_blocks").String(), itemType),
+					)
+				}
+			}
+			validateContentBlocks(&resp.Diagnostics, item.ContentBlocks, itemPath.AtName("content_blocks"))
+		case "anthropic_message":
+			if !item.Content.IsUnknown() && !item.ContentBlocks.IsUnknown() {
+				contentSet := !item.Content.IsNull()
+				blocksSet := !item.ContentBlocks.IsNull()
+				if contentSet == blocksSet {
+					resp.Diagnostics.AddAttributeError(
+						itemPath.AtName("content"),
+						"Invalid item attributes",
+						fmt.Sprintf("Exactly one of %s or %s must be set when type is %q.", itemPath.AtName("content").String(), itemPath.AtName("content_blocks").String(), itemType),
+					)
+				}
+			}
+			if !item.Role.IsUnknown() && !item.Role.IsNull() {
+				role := item.Role.ValueString()
+				if role != "user" && role != "assistant" {
+					resp.Diagnostics.AddAttributeError(
+						itemPath.AtName("role"),
+						"Invalid item role",
+						fmt.Sprintf("%s must be either \"user\" or \"assistant\" when type is %q.", itemPath.AtName("role").String(), itemType),
+					)
+				}
+			}
+			validateContentBlocks(&resp.Diagnostics, item.ContentBlocks, itemPath.AtName("content_blocks"))
 		}
 	}
 }
@@ -439,6 +511,32 @@ func validateUnexpectedString(diags *diag.Diagnostics, value types.String, attrP
 	diags.AddAttributeError(attrPath, "Unexpected item attribute", fmt.Sprintf("%s must not be set when type is %q.", attrPath.String(), itemType))
 }
 
+func validateContentBlocks(diags *diag.Diagnostics, value types.String, attrPath path.Path) {
+	if value.IsUnknown() || value.IsNull() {
+		return
+	}
+
+	var blocks []struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal([]byte(value.ValueString()), &blocks); err != nil {
+		diags.AddAttributeError(attrPath, "Invalid content_blocks", fmt.Sprintf("%s must be a JSON-encoded array of objects with a type field of \"text\", \"tool_use\", or \"tool_result\": %s.", attrPath.String(), err.Error()))
+		return
+	}
+
+	allowedTypes := map[string]struct{}{
+		"text":        {},
+		"tool_use":    {},
+		"tool_result": {},
+	}
+	for _, block := range blocks {
+		if _, ok := allowedTypes[block.Type]; !ok {
+			diags.AddAttributeError(attrPath, "Invalid content_blocks", fmt.Sprintf("%s must be a JSON-encoded array of objects with a type field of \"text\", \"tool_use\", or \"tool_result\".", attrPath.String()))
+			return
+		}
+	}
+}
+
 func boolPointerFromValue(value types.Bool) *bool {
 	if value.IsUnknown() || value.IsNull() || !value.ValueBool() {
 		return nil
@@ -486,6 +584,56 @@ func expandTestItems(items []testItemModel) ([]client.TestItem, diag.Diagnostics
 				return nil, diags
 			}
 			expanded = append(expanded, outputItem)
+		case "anthropic_system":
+			textSet := !item.Text.IsNull() && !item.Text.IsUnknown()
+			blocksSet := !item.ContentBlocks.IsNull() && !item.ContentBlocks.IsUnknown()
+			if textSet == blocksSet {
+				diags.AddAttributeError(
+					path.Root("items").AtListIndex(index).AtName("text"),
+					"Invalid item attributes",
+					fmt.Sprintf("Exactly one of %s or %s must be set when type is %q.", path.Root("items").AtListIndex(index).AtName("text").String(), path.Root("items").AtListIndex(index).AtName("content_blocks").String(), itemType),
+				)
+				return nil, diags
+			}
+			var systemItem client.TestItem
+			var err error
+			if textSet {
+				systemItem, err = client.NewAnthropicSystemTextItem(item.Text.ValueString())
+			} else {
+				systemItem, err = client.NewAnthropicSystemBlocksItem(json.RawMessage(item.ContentBlocks.ValueString()))
+			}
+			if err != nil {
+				diags.AddError("Error building anthropic_system item", err.Error())
+				return nil, diags
+			}
+			expanded = append(expanded, systemItem)
+		case "anthropic_message":
+			contentSet := !item.Content.IsNull() && !item.Content.IsUnknown()
+			blocksSet := !item.ContentBlocks.IsNull() && !item.ContentBlocks.IsUnknown()
+			if contentSet == blocksSet {
+				diags.AddAttributeError(
+					path.Root("items").AtListIndex(index).AtName("content"),
+					"Invalid item attributes",
+					fmt.Sprintf("Exactly one of %s or %s must be set when type is %q.", path.Root("items").AtListIndex(index).AtName("content").String(), path.Root("items").AtListIndex(index).AtName("content_blocks").String(), itemType),
+				)
+				return nil, diags
+			}
+			if item.Role.IsUnknown() || item.Role.IsNull() {
+				diags.AddAttributeError(path.Root("items").AtListIndex(index).AtName("role"), "Missing required item attribute", fmt.Sprintf("%s is required when type is %q.", path.Root("items").AtListIndex(index).AtName("role").String(), itemType))
+				return nil, diags
+			}
+			var messageItem client.TestItem
+			var err error
+			if contentSet {
+				messageItem, err = client.NewAnthropicMessageStringItem(item.Role.ValueString(), item.Content.ValueString())
+			} else {
+				messageItem, err = client.NewAnthropicMessageBlocksItem(item.Role.ValueString(), json.RawMessage(item.ContentBlocks.ValueString()))
+			}
+			if err != nil {
+				diags.AddError("Error building anthropic_message item", err.Error())
+				return nil, diags
+			}
+			expanded = append(expanded, messageItem)
 		default:
 			diags.AddAttributeError(path.Root("items").AtListIndex(index).AtName("type"), "Invalid item type", fmt.Sprintf("Unsupported item type %q.", itemType))
 			return nil, diags
@@ -511,16 +659,18 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 				return nil, diags
 			}
 			flattened = append(flattened, testItemModel{
-				Type:       types.StringValue("message"),
-				Role:       types.StringValue(messageContent.Role),
-				Content:    types.StringValue(messageContent.Content),
-				AnyRole:    types.BoolValue(messageContent.AnyRole),
-				AnyContent: types.BoolValue(messageContent.AnyContent),
-				Repeat:     types.BoolValue(messageContent.Repeat),
-				CallID:     types.StringNull(),
-				FuncName:   types.StringNull(),
-				Arguments:  types.StringNull(),
-				Output:     types.StringNull(),
+				Type:          types.StringValue("message"),
+				Role:          types.StringValue(messageContent.Role),
+				Content:       types.StringValue(messageContent.Content),
+				Text:          types.StringNull(),
+				ContentBlocks: types.StringNull(),
+				AnyRole:       types.BoolValue(messageContent.AnyRole),
+				AnyContent:    types.BoolValue(messageContent.AnyContent),
+				Repeat:        types.BoolValue(messageContent.Repeat),
+				CallID:        types.StringNull(),
+				FuncName:      types.StringNull(),
+				Arguments:     types.StringNull(),
+				Output:        types.StringNull(),
 			})
 		case "function_call":
 			callID, name, arguments, err := client.ParseFunctionCallContent(item)
@@ -529,16 +679,18 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 				return nil, diags
 			}
 			flattened = append(flattened, testItemModel{
-				Type:       types.StringValue("function_call"),
-				Role:       types.StringNull(),
-				Content:    types.StringNull(),
-				AnyRole:    types.BoolValue(false),
-				AnyContent: types.BoolValue(false),
-				Repeat:     types.BoolValue(false),
-				CallID:     types.StringValue(callID),
-				FuncName:   types.StringValue(name),
-				Arguments:  types.StringValue(arguments),
-				Output:     types.StringNull(),
+				Type:          types.StringValue("function_call"),
+				Role:          types.StringNull(),
+				Content:       types.StringNull(),
+				Text:          types.StringNull(),
+				ContentBlocks: types.StringNull(),
+				AnyRole:       types.BoolValue(false),
+				AnyContent:    types.BoolValue(false),
+				Repeat:        types.BoolValue(false),
+				CallID:        types.StringValue(callID),
+				FuncName:      types.StringValue(name),
+				Arguments:     types.StringValue(arguments),
+				Output:        types.StringNull(),
 			})
 		case "function_call_output":
 			callID, output, err := client.ParseFunctionCallOutputContent(item)
@@ -547,16 +699,72 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 				return nil, diags
 			}
 			flattened = append(flattened, testItemModel{
-				Type:       types.StringValue("function_call_output"),
-				Role:       types.StringNull(),
-				Content:    types.StringNull(),
-				AnyRole:    types.BoolValue(false),
-				AnyContent: types.BoolValue(false),
-				Repeat:     types.BoolValue(false),
-				CallID:     types.StringValue(callID),
-				FuncName:   types.StringNull(),
-				Arguments:  types.StringNull(),
-				Output:     types.StringValue(output),
+				Type:          types.StringValue("function_call_output"),
+				Role:          types.StringNull(),
+				Content:       types.StringNull(),
+				Text:          types.StringNull(),
+				ContentBlocks: types.StringNull(),
+				AnyRole:       types.BoolValue(false),
+				AnyContent:    types.BoolValue(false),
+				Repeat:        types.BoolValue(false),
+				CallID:        types.StringValue(callID),
+				FuncName:      types.StringNull(),
+				Arguments:     types.StringNull(),
+				Output:        types.StringValue(output),
+			})
+		case "anthropic_system":
+			systemContent, err := client.ParseAnthropicSystemContent(item)
+			if err != nil {
+				diags.AddError("Error parsing anthropic_system item", err.Error())
+				return nil, diags
+			}
+			textValue := types.StringNull()
+			blocksValue := types.StringNull()
+			if systemContent.Blocks != nil {
+				blocksValue = types.StringValue(string(systemContent.Blocks))
+			} else {
+				textValue = types.StringValue(systemContent.Text)
+			}
+			flattened = append(flattened, testItemModel{
+				Type:          types.StringValue("anthropic_system"),
+				Role:          types.StringNull(),
+				Content:       types.StringNull(),
+				Text:          textValue,
+				ContentBlocks: blocksValue,
+				AnyRole:       types.BoolValue(false),
+				AnyContent:    types.BoolValue(false),
+				Repeat:        types.BoolValue(false),
+				CallID:        types.StringNull(),
+				FuncName:      types.StringNull(),
+				Arguments:     types.StringNull(),
+				Output:        types.StringNull(),
+			})
+		case "anthropic_message":
+			messageContent, err := client.ParseAnthropicMessageContent(item)
+			if err != nil {
+				diags.AddError("Error parsing anthropic_message item", err.Error())
+				return nil, diags
+			}
+			contentValue := types.StringNull()
+			blocksValue := types.StringNull()
+			if messageContent.ContentBlocks != nil {
+				blocksValue = types.StringValue(string(messageContent.ContentBlocks))
+			} else {
+				contentValue = types.StringValue(messageContent.Content)
+			}
+			flattened = append(flattened, testItemModel{
+				Type:          types.StringValue("anthropic_message"),
+				Role:          types.StringValue(messageContent.Role),
+				Content:       contentValue,
+				Text:          types.StringNull(),
+				ContentBlocks: blocksValue,
+				AnyRole:       types.BoolValue(false),
+				AnyContent:    types.BoolValue(false),
+				Repeat:        types.BoolValue(false),
+				CallID:        types.StringNull(),
+				FuncName:      types.StringNull(),
+				Arguments:     types.StringNull(),
+				Output:        types.StringNull(),
 			})
 		default:
 			diags.AddAttributeError(path.Root("items").AtListIndex(index).AtName("type"), "Invalid item type", fmt.Sprintf("Unsupported item type %q.", item.Type))

--- a/internal/provider/test_resource_test.go
+++ b/internal/provider/test_resource_test.go
@@ -147,6 +147,156 @@ func TestAccTestResource_messageFlags(t *testing.T) {
 	})
 }
 
+func TestAccTestResource_anthropicSimple(t *testing.T) {
+	orgName := acctest.RandomWithPrefix("tf-org")
+	orgSlug := acctest.RandomWithPrefix("tf-org")
+	suiteName := acctest.RandomWithPrefix("tf-suite")
+	testName := acctest.RandomWithPrefix("tf-test")
+
+	items := `[
+  {
+    type = "anthropic_system"
+    text = "You are a helpful assistant."
+  },
+  {
+    type    = "anthropic_message"
+    role    = "user"
+    content = "Hello"
+  },
+  {
+    type           = "anthropic_message"
+    role           = "assistant"
+    content_blocks = jsonencode([{ type = "text", text = "Hi there!" }])
+  },
+]`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnthropicTestResourceConfig(orgName, orgSlug, suiteName, testName, "", items),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("testllm_test.test", "items.0.type", "anthropic_system"),
+					resource.TestCheckResourceAttr("testllm_test.test", "items.0.text", "You are a helpful assistant."),
+					resource.TestCheckResourceAttr("testllm_test.test", "items.1.role", "user"),
+					resource.TestCheckResourceAttr("testllm_test.test", "items.1.content", "Hello"),
+					resource.TestCheckResourceAttrSet("testllm_test.test", "items.2.content_blocks"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTestResource_anthropicToolUse(t *testing.T) {
+	orgName := acctest.RandomWithPrefix("tf-org")
+	orgSlug := acctest.RandomWithPrefix("tf-org")
+	suiteName := acctest.RandomWithPrefix("tf-suite")
+	testName := acctest.RandomWithPrefix("tf-test")
+
+	items := `[
+  {
+    type           = "anthropic_system"
+    content_blocks = jsonencode([{ type = "text", text = "Use tools when needed." }])
+  },
+  {
+    type    = "anthropic_message"
+    role    = "user"
+    content = "Lookup weather"
+  },
+  {
+    type           = "anthropic_message"
+    role           = "assistant"
+    content_blocks = jsonencode([
+      {
+        type  = "tool_use"
+        id    = "tool-1"
+        name  = "get_weather"
+        input = { location = "Portland" }
+      }
+    ])
+  },
+  {
+    type           = "anthropic_message"
+    role           = "assistant"
+    content_blocks = jsonencode([
+      {
+        type        = "tool_result"
+        tool_use_id = "tool-1"
+        content     = "Sunny"
+      }
+    ])
+  },
+]`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnthropicTestResourceConfig(orgName, orgSlug, suiteName, testName, "", items),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("testllm_test.test", "items.0.type", "anthropic_system"),
+					resource.TestCheckResourceAttr("testllm_test.test", "items.1.role", "user"),
+					resource.TestCheckResourceAttrSet("testllm_test.test", "items.2.content_blocks"),
+					resource.TestCheckResourceAttrSet("testllm_test.test", "items.3.content_blocks"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTestResource_crossProtocolAnthropicInOpenAI(t *testing.T) {
+	orgName := acctest.RandomWithPrefix("tf-org")
+	orgSlug := acctest.RandomWithPrefix("tf-org")
+	suiteName := acctest.RandomWithPrefix("tf-suite")
+	testName := acctest.RandomWithPrefix("tf-test")
+
+	items := `[
+  {
+    type = "anthropic_system"
+    text = "You are a helpful assistant."
+  }
+]`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTestResourceConfig(orgName, orgSlug, suiteName, testName, "", items),
+				ExpectError: regexp.MustCompile("(?s).+"),
+			},
+		},
+	})
+}
+
+func TestAccTestResource_crossProtocolOpenAIInAnthropic(t *testing.T) {
+	orgName := acctest.RandomWithPrefix("tf-org")
+	orgSlug := acctest.RandomWithPrefix("tf-org")
+	suiteName := acctest.RandomWithPrefix("tf-suite")
+	testName := acctest.RandomWithPrefix("tf-test")
+
+	items := `[
+  {
+    type    = "message"
+    role    = "user"
+    content = "Say hello"
+  }
+]`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAnthropicTestResourceConfig(orgName, orgSlug, suiteName, testName, "", items),
+				ExpectError: regexp.MustCompile("(?s).+"),
+			},
+		},
+	})
+}
+
 func TestAccTestResource_validateConfig(t *testing.T) {
 	orgName := acctest.RandomWithPrefix("tf-org")
 	orgSlug := acctest.RandomWithPrefix("tf-org")
@@ -188,6 +338,36 @@ func TestAccTestResource_validateConfig(t *testing.T) {
   }
 ]`
 
+	anthropicSystemMissingItems := `[
+  {
+    type = "anthropic_system"
+  }
+]`
+
+	anthropicSystemBothItems := `[
+  {
+    type           = "anthropic_system"
+    text           = "Hello"
+    content_blocks = jsonencode([{ type = "text", text = "Hi" }])
+  }
+]`
+
+	anthropicMessageMissingItems := `[
+  {
+    type = "anthropic_message"
+    role = "user"
+  }
+]`
+
+	anthropicMessageUnexpectedItems := `[
+  {
+    type    = "anthropic_message"
+    role    = "user"
+    content = "Hello"
+    call_id = "nope"
+  }
+]`
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -208,6 +388,22 @@ func TestAccTestResource_validateConfig(t *testing.T) {
 				Config:      testAccTestResourceConfig(orgName, orgSlug, suiteName, testName, "", invalidBoolItems),
 				ExpectError: regexp.MustCompile("any_role"),
 			},
+			{
+				Config:      testAccTestResourceConfig(orgName, orgSlug, suiteName, testName, "", anthropicSystemMissingItems),
+				ExpectError: regexp.MustCompile("content_blocks|text"),
+			},
+			{
+				Config:      testAccTestResourceConfig(orgName, orgSlug, suiteName, testName, "", anthropicSystemBothItems),
+				ExpectError: regexp.MustCompile("content_blocks|text"),
+			},
+			{
+				Config:      testAccTestResourceConfig(orgName, orgSlug, suiteName, testName, "", anthropicMessageMissingItems),
+				ExpectError: regexp.MustCompile("content_blocks|content"),
+			},
+			{
+				Config:      testAccTestResourceConfig(orgName, orgSlug, suiteName, testName, "", anthropicMessageUnexpectedItems),
+				ExpectError: regexp.MustCompile("call_id"),
+			},
 		},
 	})
 }
@@ -224,6 +420,31 @@ resource "testllm_organization" "test" {
 resource "testllm_test_suite" "test" {
   org_id = testllm_organization.test.id
   name   = %q
+}
+
+resource "testllm_test" "test" {
+  org_id      = testllm_organization.test.id
+  suite_id    = testllm_test_suite.test.id
+  name        = %q
+  description = %q
+  items       = %s
+}
+`, testAccProviderConfig(), orgName, orgSlug, suiteName, testName, description, items)
+}
+
+func testAccAnthropicTestResourceConfig(orgName, orgSlug, suiteName, testName, description, items string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "testllm_organization" "test" {
+  name = %q
+  slug = %q
+}
+
+resource "testllm_test_suite" "test" {
+  org_id   = testllm_organization.test.id
+  name     = %q
+  protocol = "anthropic"
 }
 
 resource "testllm_test" "test" {

--- a/internal/provider/test_resource_test.go
+++ b/internal/provider/test_resource_test.go
@@ -265,7 +265,7 @@ func TestAccTestResource_crossProtocolAnthropicInOpenAI(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTestResourceConfig(orgName, orgSlug, suiteName, testName, "", items),
-				ExpectError: regexp.MustCompile("(?s).+"),
+				ExpectError: regexp.MustCompile("(?i)items\\.0.*invalid"),
 			},
 		},
 	})
@@ -291,7 +291,7 @@ func TestAccTestResource_crossProtocolOpenAIInAnthropic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAnthropicTestResourceConfig(orgName, orgSlug, suiteName, testName, "", items),
-				ExpectError: regexp.MustCompile("(?s).+"),
+				ExpectError: regexp.MustCompile("(?i)items\\.0.*invalid"),
 			},
 		},
 	})
@@ -359,6 +359,15 @@ func TestAccTestResource_validateConfig(t *testing.T) {
   }
 ]`
 
+	anthropicMessageBothItems := `[
+  {
+    type           = "anthropic_message"
+    role           = "user"
+    content        = "Hello"
+    content_blocks = jsonencode([{ type = "text", text = "Hi" }])
+  }
+]`
+
 	anthropicMessageUnexpectedItems := `[
   {
     type    = "anthropic_message"
@@ -398,6 +407,10 @@ func TestAccTestResource_validateConfig(t *testing.T) {
 			},
 			{
 				Config:      testAccTestResourceConfig(orgName, orgSlug, suiteName, testName, "", anthropicMessageMissingItems),
+				ExpectError: regexp.MustCompile("content_blocks|content"),
+			},
+			{
+				Config:      testAccTestResourceConfig(orgName, orgSlug, suiteName, testName, "", anthropicMessageBothItems),
 				ExpectError: regexp.MustCompile("content_blocks|content"),
 			},
 			{

--- a/internal/provider/test_suite_resource.go
+++ b/internal/provider/test_suite_resource.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/agynio/terraform-provider-testllm/internal/client"
@@ -30,6 +32,7 @@ type testSuiteResourceModel struct {
 	OrgID       types.String `tfsdk:"org_id"`
 	Name        types.String `tfsdk:"name"`
 	Description types.String `tfsdk:"description"`
+	Protocol    types.String `tfsdk:"protocol"`
 	CreatedAt   types.String `tfsdk:"created_at"`
 	UpdatedAt   types.String `tfsdk:"updated_at"`
 }
@@ -69,6 +72,18 @@ func (r *testSuiteResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Computed:    true,
 				Default:     stringdefault.StaticString(""),
 			},
+			"protocol": schema.StringAttribute{
+				Description: "Protocol used by tests in the suite (openai or anthropic).",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("openai"),
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.OneOf("openai", "anthropic"),
+				},
+			},
 			"created_at": schema.StringAttribute{
 				Description: "Timestamp when the test suite was created.",
 				Computed:    true,
@@ -103,7 +118,7 @@ func (r *testSuiteResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	suite, err := r.client.CreateTestSuite(ctx, plan.OrgID.ValueString(), plan.Name.ValueString(), plan.Description.ValueString())
+	suite, err := r.client.CreateTestSuite(ctx, plan.OrgID.ValueString(), plan.Name.ValueString(), plan.Description.ValueString(), plan.Protocol.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating test suite", err.Error())
 		return
@@ -114,6 +129,7 @@ func (r *testSuiteResource) Create(ctx context.Context, req resource.CreateReque
 		OrgID:       types.StringValue(suite.OrgID),
 		Name:        types.StringValue(suite.Name),
 		Description: types.StringValue(suite.Description),
+		Protocol:    types.StringValue(suite.Protocol),
 		CreatedAt:   types.StringValue(suite.CreatedAt),
 		UpdatedAt:   types.StringValue(suite.UpdatedAt),
 	}
@@ -143,6 +159,7 @@ func (r *testSuiteResource) Read(ctx context.Context, req resource.ReadRequest, 
 		OrgID:       types.StringValue(suite.OrgID),
 		Name:        types.StringValue(suite.Name),
 		Description: types.StringValue(suite.Description),
+		Protocol:    types.StringValue(suite.Protocol),
 		CreatedAt:   types.StringValue(suite.CreatedAt),
 		UpdatedAt:   types.StringValue(suite.UpdatedAt),
 	}
@@ -170,6 +187,7 @@ func (r *testSuiteResource) Update(ctx context.Context, req resource.UpdateReque
 		OrgID:       types.StringValue(suite.OrgID),
 		Name:        types.StringValue(suite.Name),
 		Description: types.StringValue(suite.Description),
+		Protocol:    types.StringValue(suite.Protocol),
 		CreatedAt:   types.StringValue(suite.CreatedAt),
 		UpdatedAt:   types.StringValue(suite.UpdatedAt),
 	}

--- a/internal/provider/test_suite_resource_test.go
+++ b/internal/provider/test_suite_resource_test.go
@@ -21,16 +21,17 @@ func TestAccTestSuiteResource_basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTestSuiteResourceConfig(orgName, orgSlug, suiteName, "", false),
+				Config: testAccTestSuiteResourceConfig(orgName, orgSlug, suiteName, "", "", false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("testllm_test_suite.test", "name", suiteName),
 					resource.TestCheckResourceAttr("testllm_test_suite.test", "description", ""),
+					resource.TestCheckResourceAttr("testllm_test_suite.test", "protocol", "openai"),
 					resource.TestCheckResourceAttrSet("testllm_test_suite.test", "created_at"),
 					resource.TestCheckResourceAttrSet("testllm_test_suite.test", "updated_at"),
 				),
 			},
 			{
-				Config: testAccTestSuiteResourceConfig(orgName, orgSlug, updatedName, updatedDescription, true),
+				Config: testAccTestSuiteResourceConfig(orgName, orgSlug, updatedName, updatedDescription, "", true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("testllm_test_suite.test", "name", updatedName),
 					resource.TestCheckResourceAttr("testllm_test_suite.test", "description", updatedDescription),
@@ -54,10 +55,95 @@ func TestAccTestSuiteResource_basic(t *testing.T) {
 	})
 }
 
-func testAccTestSuiteResourceConfig(orgName, orgSlug, suiteName, description string, includeDescription bool) string {
+func TestAccTestSuiteResource_anthropic(t *testing.T) {
+	orgName := acctest.RandomWithPrefix("tf-org")
+	orgSlug := acctest.RandomWithPrefix("tf-org")
+	suiteName := acctest.RandomWithPrefix("tf-suite")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTestSuiteResourceConfig(orgName, orgSlug, suiteName, "", "anthropic", false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("testllm_test_suite.test", "protocol", "anthropic"),
+				),
+			},
+			{
+				ResourceName:      "testllm_test_suite.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					resourceState, ok := state.RootModule().Resources["testllm_test_suite.test"]
+					if !ok {
+						return "", fmt.Errorf("resource not found in state")
+					}
+					orgID := resourceState.Primary.Attributes["org_id"]
+					suiteID := resourceState.Primary.ID
+					return fmt.Sprintf("%s/%s", orgID, suiteID), nil
+				},
+			},
+		},
+	})
+}
+
+func TestAccTestSuiteResource_protocolRequiresReplace(t *testing.T) {
+	orgName := acctest.RandomWithPrefix("tf-org")
+	orgSlug := acctest.RandomWithPrefix("tf-org")
+	suiteName := acctest.RandomWithPrefix("tf-suite")
+	updatedName := acctest.RandomWithPrefix("tf-suite-update")
+
+	var firstID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTestSuiteResourceConfig(orgName, orgSlug, suiteName, "", "openai", false),
+				Check: resource.ComposeTestCheckFunc(
+					func(state *terraform.State) error {
+						resourceState, ok := state.RootModule().Resources["testllm_test_suite.test"]
+						if !ok {
+							return fmt.Errorf("resource not found in state")
+						}
+						firstID = resourceState.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				Config: testAccTestSuiteResourceConfig(orgName, orgSlug, updatedName, "", "anthropic", false),
+				Check: resource.ComposeTestCheckFunc(
+					func(state *terraform.State) error {
+						resourceState, ok := state.RootModule().Resources["testllm_test_suite.test"]
+						if !ok {
+							return fmt.Errorf("resource not found in state")
+						}
+						if firstID == "" {
+							return fmt.Errorf("expected prior suite ID to be set")
+						}
+						if firstID == resourceState.Primary.ID {
+							return fmt.Errorf("expected suite ID to change after protocol update")
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func testAccTestSuiteResourceConfig(orgName, orgSlug, suiteName, description, protocol string, includeDescription bool) string {
 	descriptionLine := ""
 	if includeDescription {
 		descriptionLine = fmt.Sprintf("  description = %q\n", description)
+	}
+
+	protocolLine := ""
+	if protocol != "" {
+		protocolLine = fmt.Sprintf("  protocol = %q\n", protocol)
 	}
 
 	return fmt.Sprintf(`
@@ -71,6 +157,7 @@ resource "testllm_organization" "test" {
 resource "testllm_test_suite" "test" {
   org_id = testllm_organization.test.id
   name   = %q
+%s
 %s}
-`, testAccProviderConfig(), orgName, orgSlug, suiteName, descriptionLine)
+`, testAccProviderConfig(), orgName, orgSlug, suiteName, protocolLine, descriptionLine)
 }


### PR DESCRIPTION
## Summary
- add protocol handling to test suites and client support for Anthropic items
- extend test resource schema/validation and expand/flatten for Anthropic content
- update docs/examples and acceptance coverage for protocol variants

## Testing
- go test -v ./...
- go vet ./...
- go build -v .

Refs #11