### PR TITLE
feat: add any_content for anthropic items

### DIFF
--- a/internal/client/tests.go
+++ b/internal/client/tests.go
@@ -54,27 +54,32 @@ type MessageContent struct {
 }
 
 type anthropicSystemTextContent struct {
-	Text string `json:"text"`
+	Text       string `json:"text"`
+	AnyContent *bool  `json:"any_content,omitempty"`
 }
 
 type anthropicSystemBlocksContent struct {
-	Blocks json.RawMessage `json:"blocks"`
+	Blocks     json.RawMessage `json:"blocks"`
+	AnyContent *bool           `json:"any_content,omitempty"`
 }
 
 type AnthropicSystemContent struct {
-	Text   string
-	Blocks json.RawMessage
+	Text       string
+	Blocks     json.RawMessage
+	AnyContent bool
 }
 
 type anthropicMessageContent struct {
-	Role    string          `json:"role"`
-	Content json.RawMessage `json:"content"`
+	Role       string          `json:"role"`
+	Content    json.RawMessage `json:"content"`
+	AnyContent *bool           `json:"any_content,omitempty"`
 }
 
 type AnthropicMessageContent struct {
 	Role          string
 	Content       string
 	ContentBlocks json.RawMessage
+	AnyContent    bool
 }
 
 type functionCallContent struct {
@@ -123,36 +128,52 @@ func NewFunctionCallOutputItem(callID, output string) (TestItem, error) {
 	return TestItem{Type: "function_call_output", Content: payload}, nil
 }
 
-func NewAnthropicSystemTextItem(text string) (TestItem, error) {
-	payload, err := json.Marshal(anthropicSystemTextContent{Text: text})
+func NewAnthropicSystemTextItem(text string, anyContent *bool) (TestItem, error) {
+	systemPayload := anthropicSystemTextContent{Text: text}
+	if anyContent != nil && *anyContent {
+		systemPayload.AnyContent = anyContent
+	}
+	payload, err := json.Marshal(systemPayload)
 	if err != nil {
 		return TestItem{}, err
 	}
 	return TestItem{Type: "anthropic_system", Content: payload}, nil
 }
 
-func NewAnthropicSystemBlocksItem(blocksJSON json.RawMessage) (TestItem, error) {
-	payload, err := json.Marshal(anthropicSystemBlocksContent{Blocks: blocksJSON})
+func NewAnthropicSystemBlocksItem(blocksJSON json.RawMessage, anyContent *bool) (TestItem, error) {
+	systemPayload := anthropicSystemBlocksContent{Blocks: blocksJSON}
+	if anyContent != nil && *anyContent {
+		systemPayload.AnyContent = anyContent
+	}
+	payload, err := json.Marshal(systemPayload)
 	if err != nil {
 		return TestItem{}, err
 	}
 	return TestItem{Type: "anthropic_system", Content: payload}, nil
 }
 
-func NewAnthropicMessageStringItem(role, content string) (TestItem, error) {
+func NewAnthropicMessageStringItem(role, content string, anyContent *bool) (TestItem, error) {
 	contentPayload, err := json.Marshal(content)
 	if err != nil {
 		return TestItem{}, err
 	}
-	payload, err := json.Marshal(anthropicMessageContent{Role: role, Content: json.RawMessage(contentPayload)})
+	messagePayload := anthropicMessageContent{Role: role, Content: json.RawMessage(contentPayload)}
+	if anyContent != nil && *anyContent {
+		messagePayload.AnyContent = anyContent
+	}
+	payload, err := json.Marshal(messagePayload)
 	if err != nil {
 		return TestItem{}, err
 	}
 	return TestItem{Type: "anthropic_message", Content: payload}, nil
 }
 
-func NewAnthropicMessageBlocksItem(role string, blocksJSON json.RawMessage) (TestItem, error) {
-	payload, err := json.Marshal(anthropicMessageContent{Role: role, Content: blocksJSON})
+func NewAnthropicMessageBlocksItem(role string, blocksJSON json.RawMessage, anyContent *bool) (TestItem, error) {
+	messagePayload := anthropicMessageContent{Role: role, Content: blocksJSON}
+	if anyContent != nil && *anyContent {
+		messagePayload.AnyContent = anyContent
+	}
+	payload, err := json.Marshal(messagePayload)
 	if err != nil {
 		return TestItem{}, err
 	}
@@ -203,6 +224,12 @@ func ParseAnthropicSystemContent(item TestItem) (AnthropicSystemContent, error) 
 	}
 	textPayload, hasText := payload["text"]
 	blocksPayload, hasBlocks := payload["blocks"]
+	anyContent := false
+	if anyContentPayload, hasAnyContent := payload["any_content"]; hasAnyContent {
+		if err := json.Unmarshal(anyContentPayload, &anyContent); err != nil {
+			return AnthropicSystemContent{}, err
+		}
+	}
 	if hasText && hasBlocks {
 		return AnthropicSystemContent{}, fmt.Errorf("anthropic_system content must include either text or blocks")
 	}
@@ -211,10 +238,10 @@ func ParseAnthropicSystemContent(item TestItem) (AnthropicSystemContent, error) 
 		if err := json.Unmarshal(textPayload, &text); err != nil {
 			return AnthropicSystemContent{}, err
 		}
-		return AnthropicSystemContent{Text: text}, nil
+		return AnthropicSystemContent{Text: text, AnyContent: anyContent}, nil
 	}
 	if hasBlocks {
-		return AnthropicSystemContent{Blocks: blocksPayload}, nil
+		return AnthropicSystemContent{Blocks: blocksPayload, AnyContent: anyContent}, nil
 	}
 	return AnthropicSystemContent{}, fmt.Errorf("anthropic_system content missing text or blocks")
 }
@@ -236,13 +263,13 @@ func ParseAnthropicMessageContent(item TestItem) (AnthropicMessageContent, error
 		if err := json.Unmarshal(payload.Content, &textContent); err != nil {
 			return AnthropicMessageContent{}, fmt.Errorf("anthropic_message string content: %w", err)
 		}
-		return AnthropicMessageContent{Role: payload.Role, Content: textContent}, nil
+		return AnthropicMessageContent{Role: payload.Role, Content: textContent, AnyContent: boolFromPointer(payload.AnyContent)}, nil
 	case '[':
 		var blocks []json.RawMessage
 		if err := json.Unmarshal(payload.Content, &blocks); err != nil {
 			return AnthropicMessageContent{}, fmt.Errorf("anthropic_message content must be a JSON string or array: %w", err)
 		}
-		return AnthropicMessageContent{Role: payload.Role, ContentBlocks: payload.Content}, nil
+		return AnthropicMessageContent{Role: payload.Role, ContentBlocks: payload.Content, AnyContent: boolFromPointer(payload.AnyContent)}, nil
 	default:
 		return AnthropicMessageContent{}, fmt.Errorf("anthropic_message content must be a JSON string or array")
 	}

--- a/internal/provider/test_resource.go
+++ b/internal/provider/test_resource.go
@@ -294,7 +294,11 @@ func (r *testResource) ValidateConfig(ctx context.Context, req resource.Validate
 			if value.IsUnknown() || value.IsNull() || !value.ValueBool() {
 				continue
 			}
-			if itemType != "message" {
+			allowed := itemType == "message"
+			if rule.Name == "any_content" {
+				allowed = itemType == "message" || itemType == "anthropic_message" || itemType == "anthropic_system"
+			}
+			if !allowed {
 				resp.Diagnostics.AddAttributeError(attrPath, "Unexpected item attribute", fmt.Sprintf("%s must not be true when type is %q.", attrPath.String(), itemType))
 				continue
 			}
@@ -597,10 +601,11 @@ func expandTestItems(items []testItemModel) ([]client.TestItem, diag.Diagnostics
 			}
 			var systemItem client.TestItem
 			var err error
+			anyContent := boolPointerFromValue(item.AnyContent)
 			if textSet {
-				systemItem, err = client.NewAnthropicSystemTextItem(item.Text.ValueString())
+				systemItem, err = client.NewAnthropicSystemTextItem(item.Text.ValueString(), anyContent)
 			} else {
-				systemItem, err = client.NewAnthropicSystemBlocksItem(json.RawMessage(item.ContentBlocks.ValueString()))
+				systemItem, err = client.NewAnthropicSystemBlocksItem(json.RawMessage(item.ContentBlocks.ValueString()), anyContent)
 			}
 			if err != nil {
 				diags.AddError("Error building anthropic_system item", err.Error())
@@ -624,10 +629,11 @@ func expandTestItems(items []testItemModel) ([]client.TestItem, diag.Diagnostics
 			}
 			var messageItem client.TestItem
 			var err error
+			anyContent := boolPointerFromValue(item.AnyContent)
 			if contentSet {
-				messageItem, err = client.NewAnthropicMessageStringItem(item.Role.ValueString(), item.Content.ValueString())
+				messageItem, err = client.NewAnthropicMessageStringItem(item.Role.ValueString(), item.Content.ValueString(), anyContent)
 			} else {
-				messageItem, err = client.NewAnthropicMessageBlocksItem(item.Role.ValueString(), json.RawMessage(item.ContentBlocks.ValueString()))
+				messageItem, err = client.NewAnthropicMessageBlocksItem(item.Role.ValueString(), json.RawMessage(item.ContentBlocks.ValueString()), anyContent)
 			}
 			if err != nil {
 				diags.AddError("Error building anthropic_message item", err.Error())
@@ -732,7 +738,7 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 				Text:          textValue,
 				ContentBlocks: blocksValue,
 				AnyRole:       types.BoolValue(false),
-				AnyContent:    types.BoolValue(false),
+				AnyContent:    types.BoolValue(systemContent.AnyContent),
 				Repeat:        types.BoolValue(false),
 				CallID:        types.StringNull(),
 				FuncName:      types.StringNull(),
@@ -759,7 +765,7 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 				Text:          types.StringNull(),
 				ContentBlocks: blocksValue,
 				AnyRole:       types.BoolValue(false),
-				AnyContent:    types.BoolValue(false),
+				AnyContent:    types.BoolValue(messageContent.AnyContent),
 				Repeat:        types.BoolValue(false),
 				CallID:        types.StringNull(),
 				FuncName:      types.StringNull(),

--- a/internal/provider/test_resource.go
+++ b/internal/provider/test_resource.go
@@ -305,7 +305,7 @@ func (r *testResource) ValidateConfig(ctx context.Context, req resource.Validate
 			if item.Role.IsUnknown() || item.Role.IsNull() {
 				continue
 			}
-			if item.Role.ValueString() == "assistant" {
+			if item.Role.ValueString() == "assistant" && itemType == "message" {
 				resp.Diagnostics.AddAttributeError(attrPath, "Unexpected item attribute", fmt.Sprintf("%s must not be true when type is %q and role is %q.", attrPath.String(), itemType, item.Role.ValueString()))
 			}
 		}


### PR DESCRIPTION
## Summary
- add any_content support to anthropic system/message client payloads
- allow any_content in test resource validation and expand/flatten handling

## Testing
- go test ./...
- go vet ./...

Relates to #15