### PR TITLE
fix: normalize test item JSON

### DIFF
--- a/internal/provider/test_resource.go
+++ b/internal/provider/test_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -541,6 +542,26 @@ func validateContentBlocks(diags *diag.Diagnostics, value types.String, attrPath
 	}
 }
 
+func normalizeJSON(value string) (string, error) {
+	decoder := json.NewDecoder(strings.NewReader(value))
+	decoder.UseNumber()
+	var payload interface{}
+	if err := decoder.Decode(&payload); err != nil {
+		return "", err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return "", fmt.Errorf("unexpected trailing data")
+		}
+		return "", err
+	}
+	normalized, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	return string(normalized), nil
+}
+
 func boolPointerFromValue(value types.Bool) *bool {
 	if value.IsUnknown() || value.IsNull() || !value.ValueBool() {
 		return nil
@@ -575,7 +596,16 @@ func expandTestItems(items []testItemModel) ([]client.TestItem, diag.Diagnostics
 			}
 			expanded = append(expanded, messageItem)
 		case "function_call":
-			callItem, err := client.NewFunctionCallItem(item.CallID.ValueString(), item.FuncName.ValueString(), item.Arguments.ValueString())
+			arguments, err := normalizeJSON(item.Arguments.ValueString())
+			if err != nil {
+				diags.AddAttributeError(
+					path.Root("items").AtListIndex(index).AtName("arguments"),
+					"Invalid arguments",
+					fmt.Sprintf("%s must be valid JSON: %s.", path.Root("items").AtListIndex(index).AtName("arguments").String(), err.Error()),
+				)
+				return nil, diags
+			}
+			callItem, err := client.NewFunctionCallItem(item.CallID.ValueString(), item.FuncName.ValueString(), arguments)
 			if err != nil {
 				diags.AddError("Error building function_call item", err.Error())
 				return nil, diags
@@ -605,7 +635,16 @@ func expandTestItems(items []testItemModel) ([]client.TestItem, diag.Diagnostics
 			if textSet {
 				systemItem, err = client.NewAnthropicSystemTextItem(item.Text.ValueString(), anyContent)
 			} else {
-				systemItem, err = client.NewAnthropicSystemBlocksItem(json.RawMessage(item.ContentBlocks.ValueString()), anyContent)
+				blocks, err := normalizeJSON(item.ContentBlocks.ValueString())
+				if err != nil {
+					diags.AddAttributeError(
+						path.Root("items").AtListIndex(index).AtName("content_blocks"),
+						"Invalid content_blocks",
+						fmt.Sprintf("%s must be valid JSON: %s.", path.Root("items").AtListIndex(index).AtName("content_blocks").String(), err.Error()),
+					)
+					return nil, diags
+				}
+				systemItem, err = client.NewAnthropicSystemBlocksItem(json.RawMessage(blocks), anyContent)
 			}
 			if err != nil {
 				diags.AddError("Error building anthropic_system item", err.Error())
@@ -633,7 +672,16 @@ func expandTestItems(items []testItemModel) ([]client.TestItem, diag.Diagnostics
 			if contentSet {
 				messageItem, err = client.NewAnthropicMessageStringItem(item.Role.ValueString(), item.Content.ValueString(), anyContent)
 			} else {
-				messageItem, err = client.NewAnthropicMessageBlocksItem(item.Role.ValueString(), json.RawMessage(item.ContentBlocks.ValueString()), anyContent)
+				blocks, err := normalizeJSON(item.ContentBlocks.ValueString())
+				if err != nil {
+					diags.AddAttributeError(
+						path.Root("items").AtListIndex(index).AtName("content_blocks"),
+						"Invalid content_blocks",
+						fmt.Sprintf("%s must be valid JSON: %s.", path.Root("items").AtListIndex(index).AtName("content_blocks").String(), err.Error()),
+					)
+					return nil, diags
+				}
+				messageItem, err = client.NewAnthropicMessageBlocksItem(item.Role.ValueString(), json.RawMessage(blocks), anyContent)
 			}
 			if err != nil {
 				diags.AddError("Error building anthropic_message item", err.Error())
@@ -684,6 +732,11 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 				diags.AddError("Error parsing function_call item", err.Error())
 				return nil, diags
 			}
+			normalizedArguments, err := normalizeJSON(arguments)
+			if err != nil {
+				diags.AddError("Error normalizing function_call arguments", err.Error())
+				return nil, diags
+			}
 			flattened = append(flattened, testItemModel{
 				Type:          types.StringValue("function_call"),
 				Role:          types.StringNull(),
@@ -695,7 +748,7 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 				Repeat:        types.BoolValue(false),
 				CallID:        types.StringValue(callID),
 				FuncName:      types.StringValue(name),
-				Arguments:     types.StringValue(arguments),
+				Arguments:     types.StringValue(normalizedArguments),
 				Output:        types.StringNull(),
 			})
 		case "function_call_output":
@@ -727,7 +780,12 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 			textValue := types.StringNull()
 			blocksValue := types.StringNull()
 			if systemContent.Blocks != nil {
-				blocksValue = types.StringValue(string(systemContent.Blocks))
+				blocks, err := normalizeJSON(string(systemContent.Blocks))
+				if err != nil {
+					diags.AddError("Error normalizing anthropic_system content_blocks", err.Error())
+					return nil, diags
+				}
+				blocksValue = types.StringValue(blocks)
 			} else {
 				textValue = types.StringValue(systemContent.Text)
 			}
@@ -754,7 +812,12 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 			contentValue := types.StringNull()
 			blocksValue := types.StringNull()
 			if messageContent.ContentBlocks != nil {
-				blocksValue = types.StringValue(string(messageContent.ContentBlocks))
+				blocks, err := normalizeJSON(string(messageContent.ContentBlocks))
+				if err != nil {
+					diags.AddError("Error normalizing anthropic_message content_blocks", err.Error())
+					return nil, diags
+				}
+				blocksValue = types.StringValue(blocks)
 			} else {
 				contentValue = types.StringValue(messageContent.Content)
 			}

--- a/internal/provider/test_resource.go
+++ b/internal/provider/test_resource.go
@@ -562,6 +562,15 @@ func normalizeJSON(value string) (string, error) {
 	return string(normalized), nil
 }
 
+func normalizeJSONAttr(value string, attrPath path.Path, diags *diag.Diagnostics, summary string) (string, bool) {
+	normalized, err := normalizeJSON(value)
+	if err != nil {
+		diags.AddAttributeError(attrPath, summary, fmt.Sprintf("%s must be valid JSON: %s.", attrPath.String(), err.Error()))
+		return "", false
+	}
+	return normalized, true
+}
+
 func boolPointerFromValue(value types.Bool) *bool {
 	if value.IsUnknown() || value.IsNull() || !value.ValueBool() {
 		return nil
@@ -596,13 +605,9 @@ func expandTestItems(items []testItemModel) ([]client.TestItem, diag.Diagnostics
 			}
 			expanded = append(expanded, messageItem)
 		case "function_call":
-			arguments, err := normalizeJSON(item.Arguments.ValueString())
-			if err != nil {
-				diags.AddAttributeError(
-					path.Root("items").AtListIndex(index).AtName("arguments"),
-					"Invalid arguments",
-					fmt.Sprintf("%s must be valid JSON: %s.", path.Root("items").AtListIndex(index).AtName("arguments").String(), err.Error()),
-				)
+			attrPath := path.Root("items").AtListIndex(index).AtName("arguments")
+			arguments, ok := normalizeJSONAttr(item.Arguments.ValueString(), attrPath, &diags, "Invalid arguments")
+			if !ok {
 				return nil, diags
 			}
 			callItem, err := client.NewFunctionCallItem(item.CallID.ValueString(), item.FuncName.ValueString(), arguments)
@@ -635,13 +640,9 @@ func expandTestItems(items []testItemModel) ([]client.TestItem, diag.Diagnostics
 			if textSet {
 				systemItem, err = client.NewAnthropicSystemTextItem(item.Text.ValueString(), anyContent)
 			} else {
-				blocks, err := normalizeJSON(item.ContentBlocks.ValueString())
-				if err != nil {
-					diags.AddAttributeError(
-						path.Root("items").AtListIndex(index).AtName("content_blocks"),
-						"Invalid content_blocks",
-						fmt.Sprintf("%s must be valid JSON: %s.", path.Root("items").AtListIndex(index).AtName("content_blocks").String(), err.Error()),
-					)
+				attrPath := path.Root("items").AtListIndex(index).AtName("content_blocks")
+				blocks, ok := normalizeJSONAttr(item.ContentBlocks.ValueString(), attrPath, &diags, "Invalid content_blocks")
+				if !ok {
 					return nil, diags
 				}
 				systemItem, err = client.NewAnthropicSystemBlocksItem(json.RawMessage(blocks), anyContent)
@@ -672,13 +673,9 @@ func expandTestItems(items []testItemModel) ([]client.TestItem, diag.Diagnostics
 			if contentSet {
 				messageItem, err = client.NewAnthropicMessageStringItem(item.Role.ValueString(), item.Content.ValueString(), anyContent)
 			} else {
-				blocks, err := normalizeJSON(item.ContentBlocks.ValueString())
-				if err != nil {
-					diags.AddAttributeError(
-						path.Root("items").AtListIndex(index).AtName("content_blocks"),
-						"Invalid content_blocks",
-						fmt.Sprintf("%s must be valid JSON: %s.", path.Root("items").AtListIndex(index).AtName("content_blocks").String(), err.Error()),
-					)
+				attrPath := path.Root("items").AtListIndex(index).AtName("content_blocks")
+				blocks, ok := normalizeJSONAttr(item.ContentBlocks.ValueString(), attrPath, &diags, "Invalid content_blocks")
+				if !ok {
 					return nil, diags
 				}
 				messageItem, err = client.NewAnthropicMessageBlocksItem(item.Role.ValueString(), json.RawMessage(blocks), anyContent)

--- a/internal/provider/test_resource_normalization_test.go
+++ b/internal/provider/test_resource_normalization_test.go
@@ -1,0 +1,102 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/agynio/terraform-provider-testllm/internal/client"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestExpandTestItems_normalizesJSON(t *testing.T) {
+	arguments := `{"z":1,"a":2}`
+	blocks := `[
+  {"type":"tool_use","id":"tool-1","name":"get_weather","input":{"z":1,"a":2}}
+]`
+	items := []testItemModel{
+		{
+			Type:          types.StringValue("function_call"),
+			Role:          types.StringNull(),
+			Content:       types.StringNull(),
+			Text:          types.StringNull(),
+			ContentBlocks: types.StringNull(),
+			AnyRole:       types.BoolValue(false),
+			AnyContent:    types.BoolValue(false),
+			Repeat:        types.BoolValue(false),
+			CallID:        types.StringValue("call-1"),
+			FuncName:      types.StringValue("get_data"),
+			Arguments:     types.StringValue(arguments),
+			Output:        types.StringNull(),
+		},
+		{
+			Type:          types.StringValue("anthropic_message"),
+			Role:          types.StringValue("assistant"),
+			Content:       types.StringNull(),
+			Text:          types.StringNull(),
+			ContentBlocks: types.StringValue(blocks),
+			AnyRole:       types.BoolValue(false),
+			AnyContent:    types.BoolValue(false),
+			Repeat:        types.BoolValue(false),
+			CallID:        types.StringNull(),
+			FuncName:      types.StringNull(),
+			Arguments:     types.StringNull(),
+			Output:        types.StringNull(),
+		},
+	}
+
+	expanded, diags := expandTestItems(items)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if len(expanded) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(expanded))
+	}
+
+	_, _, normalizedArgs, err := client.ParseFunctionCallContent(expanded[0])
+	if err != nil {
+		t.Fatalf("parse function_call item: %v", err)
+	}
+	if normalizedArgs != `{"a":2,"z":1}` {
+		t.Fatalf("expected normalized arguments, got %q", normalizedArgs)
+	}
+
+	messageContent, err := client.ParseAnthropicMessageContent(expanded[1])
+	if err != nil {
+		t.Fatalf("parse anthropic_message item: %v", err)
+	}
+	if messageContent.ContentBlocks == nil {
+		t.Fatalf("expected content blocks to be set")
+	}
+	if string(messageContent.ContentBlocks) != `[{"id":"tool-1","input":{"a":2,"z":1},"name":"get_weather","type":"tool_use"}]` {
+		t.Fatalf("expected normalized content blocks, got %s", messageContent.ContentBlocks)
+	}
+}
+
+func TestFlattenTestItems_normalizesJSON(t *testing.T) {
+	arguments := `{"z":1,"a":2}`
+	callItem, err := client.NewFunctionCallItem("call-1", "get_data", arguments)
+	if err != nil {
+		t.Fatalf("build function_call item: %v", err)
+	}
+
+	blocks := json.RawMessage(`[{"type":"tool_use","id":"tool-1","name":"get_weather","input":{"z":1,"a":2}}]`)
+	messageItem, err := client.NewAnthropicMessageBlocksItem("assistant", blocks, nil)
+	if err != nil {
+		t.Fatalf("build anthropic_message item: %v", err)
+	}
+
+	flattened, diags := flattenTestItems([]client.TestItem{callItem, messageItem})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if len(flattened) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(flattened))
+	}
+
+	if flattened[0].Arguments.ValueString() != `{"a":2,"z":1}` {
+		t.Fatalf("expected normalized arguments, got %q", flattened[0].Arguments.ValueString())
+	}
+	if flattened[1].ContentBlocks.ValueString() != `[{"id":"tool-1","input":{"a":2,"z":1},"name":"get_weather","type":"tool_use"}]` {
+		t.Fatalf("expected normalized content blocks, got %q", flattened[1].ContentBlocks.ValueString())
+	}
+}

--- a/internal/provider/test_resource_normalization_test.go
+++ b/internal/provider/test_resource_normalization_test.go
@@ -2,16 +2,79 @@ package provider
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/agynio/terraform-provider-testllm/internal/client"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+func TestNormalizeJSON(t *testing.T) {
+	t.Run("sorts keys", func(t *testing.T) {
+		normalized, err := normalizeJSON(`{"z":1,"a":2}`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if normalized != `{"a":2,"z":1}` {
+			t.Fatalf("expected normalized JSON, got %q", normalized)
+		}
+	})
+
+	t.Run("idempotent", func(t *testing.T) {
+		input := `{"a":2,"z":1}`
+		normalized, err := normalizeJSON(input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if normalized != input {
+			t.Fatalf("expected %q, got %q", input, normalized)
+		}
+	})
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		if _, err := normalizeJSON(`{"a":}`); err == nil {
+			t.Fatalf("expected error for invalid JSON")
+		}
+	})
+
+	t.Run("trailing data", func(t *testing.T) {
+		if _, err := normalizeJSON(`{"a":1} {"b":2}`); err == nil {
+			t.Fatalf("expected trailing data error")
+		} else if !strings.Contains(err.Error(), "unexpected trailing data") {
+			t.Fatalf("expected trailing data error, got %v", err)
+		}
+	})
+
+	t.Run("numeric precision", func(t *testing.T) {
+		normalized, err := normalizeJSON(`{"big":9007199254740993}`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if normalized != `{"big":9007199254740993}` {
+			t.Fatalf("expected precision preserved, got %q", normalized)
+		}
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		if _, err := normalizeJSON(""); err == nil {
+			t.Fatalf("expected error for empty string")
+		}
+	})
+
+	t.Run("whitespace string", func(t *testing.T) {
+		if _, err := normalizeJSON(" \n\t "); err == nil {
+			t.Fatalf("expected error for whitespace string")
+		}
+	})
+}
+
 func TestExpandTestItems_normalizesJSON(t *testing.T) {
 	arguments := `{"z":1,"a":2}`
 	blocks := `[
   {"type":"tool_use","id":"tool-1","name":"get_weather","input":{"z":1,"a":2}}
+]`
+	systemBlocks := `[
+  {"text":"Welcome","type":"text","meta":{"z":1,"a":2}}
 ]`
 	items := []testItemModel{
 		{
@@ -42,14 +105,28 @@ func TestExpandTestItems_normalizesJSON(t *testing.T) {
 			Arguments:     types.StringNull(),
 			Output:        types.StringNull(),
 		},
+		{
+			Type:          types.StringValue("anthropic_system"),
+			Role:          types.StringNull(),
+			Content:       types.StringNull(),
+			Text:          types.StringNull(),
+			ContentBlocks: types.StringValue(systemBlocks),
+			AnyRole:       types.BoolValue(false),
+			AnyContent:    types.BoolValue(false),
+			Repeat:        types.BoolValue(false),
+			CallID:        types.StringNull(),
+			FuncName:      types.StringNull(),
+			Arguments:     types.StringNull(),
+			Output:        types.StringNull(),
+		},
 	}
 
 	expanded, diags := expandTestItems(items)
 	if diags.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", diags)
 	}
-	if len(expanded) != 2 {
-		t.Fatalf("expected 2 items, got %d", len(expanded))
+	if len(expanded) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(expanded))
 	}
 
 	_, _, normalizedArgs, err := client.ParseFunctionCallContent(expanded[0])
@@ -70,6 +147,17 @@ func TestExpandTestItems_normalizesJSON(t *testing.T) {
 	if string(messageContent.ContentBlocks) != `[{"id":"tool-1","input":{"a":2,"z":1},"name":"get_weather","type":"tool_use"}]` {
 		t.Fatalf("expected normalized content blocks, got %s", messageContent.ContentBlocks)
 	}
+
+	systemContent, err := client.ParseAnthropicSystemContent(expanded[2])
+	if err != nil {
+		t.Fatalf("parse anthropic_system item: %v", err)
+	}
+	if systemContent.Blocks == nil {
+		t.Fatalf("expected system content blocks to be set")
+	}
+	if string(systemContent.Blocks) != `[{"meta":{"a":2,"z":1},"text":"Welcome","type":"text"}]` {
+		t.Fatalf("expected normalized system blocks, got %s", systemContent.Blocks)
+	}
 }
 
 func TestFlattenTestItems_normalizesJSON(t *testing.T) {
@@ -85,12 +173,18 @@ func TestFlattenTestItems_normalizesJSON(t *testing.T) {
 		t.Fatalf("build anthropic_message item: %v", err)
 	}
 
-	flattened, diags := flattenTestItems([]client.TestItem{callItem, messageItem})
+	systemBlocks := json.RawMessage(`[{"text":"Welcome","type":"text","meta":{"z":1,"a":2}}]`)
+	systemItem, err := client.NewAnthropicSystemBlocksItem(systemBlocks, nil)
+	if err != nil {
+		t.Fatalf("build anthropic_system item: %v", err)
+	}
+
+	flattened, diags := flattenTestItems([]client.TestItem{callItem, messageItem, systemItem})
 	if diags.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", diags)
 	}
-	if len(flattened) != 2 {
-		t.Fatalf("expected 2 items, got %d", len(flattened))
+	if len(flattened) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(flattened))
 	}
 
 	if flattened[0].Arguments.ValueString() != `{"a":2,"z":1}` {
@@ -98,5 +192,8 @@ func TestFlattenTestItems_normalizesJSON(t *testing.T) {
 	}
 	if flattened[1].ContentBlocks.ValueString() != `[{"id":"tool-1","input":{"a":2,"z":1},"name":"get_weather","type":"tool_use"}]` {
 		t.Fatalf("expected normalized content blocks, got %q", flattened[1].ContentBlocks.ValueString())
+	}
+	if flattened[2].ContentBlocks.ValueString() != `[{"meta":{"a":2,"z":1},"text":"Welcome","type":"text"}]` {
+		t.Fatalf("expected normalized system blocks, got %q", flattened[2].ContentBlocks.ValueString())
 	}
 }

--- a/internal/provider/test_resource_test.go
+++ b/internal/provider/test_resource_test.go
@@ -90,18 +90,25 @@ func TestAccTestResource_functionCallItems(t *testing.T) {
   },
 ]`
 
+	config := testAccTestResourceConfig(orgName, orgSlug, suiteName, testName, "", items)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTestResourceConfig(orgName, orgSlug, suiteName, testName, "", items),
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("testllm_test.test", "items.0.type", "function_call"),
 					resource.TestCheckResourceAttr("testllm_test.test", "items.0.func_name", "get_data"),
 					resource.TestCheckResourceAttr("testllm_test.test", "items.1.type", "function_call_output"),
 					resource.TestCheckResourceAttr("testllm_test.test", "items.1.output", "done"),
 				),
+			},
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})
@@ -229,18 +236,25 @@ func TestAccTestResource_anthropicToolUse(t *testing.T) {
   },
 ]`
 
+	config := testAccAnthropicTestResourceConfig(orgName, orgSlug, suiteName, testName, "", items)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAnthropicTestResourceConfig(orgName, orgSlug, suiteName, testName, "", items),
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("testllm_test.test", "items.0.type", "anthropic_system"),
 					resource.TestCheckResourceAttr("testllm_test.test", "items.1.role", "user"),
 					resource.TestCheckResourceAttrSet("testllm_test.test", "items.2.content_blocks"),
 					resource.TestCheckResourceAttrSet("testllm_test.test", "items.3.content_blocks"),
 				),
+			},
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})


### PR DESCRIPTION
## Summary
- normalize JSON for function_call arguments and content_blocks during expand/flatten
- add unit coverage for JSON normalization
- add acceptance plan-only checks to prevent drift

## Testing
- go test ./...
- go vet ./...

Closes #17