### PR TITLE
fix(provider): use jsontypes JSON

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/agynio/terraform-provider-testllm
 go 1.25.0
 
 require (
+	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.16.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/hashicorp/terraform-json v0.27.2 h1:BwGuzM6iUPqf9JYM/Z4AF1OJ5VVJEEzoK
 github.com/hashicorp/terraform-json v0.27.2/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
 github.com/hashicorp/terraform-plugin-framework v1.19.0 h1:q0bwyhxAOR3vfdgbk9iplv3MlTv/dhBHTXjQOtQDoBA=
 github.com/hashicorp/terraform-plugin-framework v1.19.0/go.mod h1:YRXOBu0jvs7xp4AThBbX4mAzYaMJ1JgtFH//oGKxwLc=
+github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0 h1:SJXL5FfJJm17554Kpt9jFXngdM6fXbnUnZ6iT2IeiYA=
+github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0/go.mod h1:p0phD0IYhsu9bR4+6OetVvvH59I6LwjXGnTVEr8ox6E=
 github.com/hashicorp/terraform-plugin-framework-validators v0.16.0 h1:O9QqGoYDzQT7lwTXUsZEtgabeWW96zUBh47Smn2lkFA=
 github.com/hashicorp/terraform-plugin-framework-validators v0.16.0/go.mod h1:Bh89/hNmqsEWug4/XWKYBwtnw3tbz5BAy1L1OgvbIaY=
 github.com/hashicorp/terraform-plugin-go v0.31.0 h1:0Fz2r9DQ+kNNl6bx8HRxFd1TfMKUvnrOtvJPmp3Z0q8=

--- a/internal/provider/test_resource.go
+++ b/internal/provider/test_resource.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -44,23 +44,29 @@ type testResourceModel struct {
 }
 
 type testItemModel struct {
-	Type          types.String `tfsdk:"type"`
-	Role          types.String `tfsdk:"role"`
-	Content       types.String `tfsdk:"content"`
-	Text          types.String `tfsdk:"text"`
-	ContentBlocks types.String `tfsdk:"content_blocks"`
-	AnyRole       types.Bool   `tfsdk:"any_role"`
-	AnyContent    types.Bool   `tfsdk:"any_content"`
-	Repeat        types.Bool   `tfsdk:"repeat"`
-	CallID        types.String `tfsdk:"call_id"`
-	FuncName      types.String `tfsdk:"func_name"`
-	Arguments     types.String `tfsdk:"arguments"`
-	Output        types.String `tfsdk:"output"`
+	Type          types.String         `tfsdk:"type"`
+	Role          types.String         `tfsdk:"role"`
+	Content       types.String         `tfsdk:"content"`
+	Text          types.String         `tfsdk:"text"`
+	ContentBlocks jsontypes.Normalized `tfsdk:"content_blocks"`
+	AnyRole       types.Bool           `tfsdk:"any_role"`
+	AnyContent    types.Bool           `tfsdk:"any_content"`
+	Repeat        types.Bool           `tfsdk:"repeat"`
+	CallID        types.String         `tfsdk:"call_id"`
+	FuncName      types.String         `tfsdk:"func_name"`
+	Arguments     jsontypes.Normalized `tfsdk:"arguments"`
+	Output        types.String         `tfsdk:"output"`
+}
+
+type stringValue interface {
+	IsNull() bool
+	IsUnknown() bool
+	ValueString() string
 }
 
 type itemFieldRule struct {
 	Name     string
-	Getter   func(testItemModel) types.String
+	Getter   func(testItemModel) stringValue
 	Required bool
 }
 
@@ -71,50 +77,50 @@ type itemBoolFieldRule struct {
 
 var testItemValidationRules = map[string][]itemFieldRule{
 	"message": {
-		{Name: "role", Getter: func(item testItemModel) types.String { return item.Role }, Required: true},
-		{Name: "content", Getter: func(item testItemModel) types.String { return item.Content }, Required: true},
-		{Name: "call_id", Getter: func(item testItemModel) types.String { return item.CallID }},
-		{Name: "func_name", Getter: func(item testItemModel) types.String { return item.FuncName }},
-		{Name: "arguments", Getter: func(item testItemModel) types.String { return item.Arguments }},
-		{Name: "output", Getter: func(item testItemModel) types.String { return item.Output }},
-		{Name: "text", Getter: func(item testItemModel) types.String { return item.Text }},
-		{Name: "content_blocks", Getter: func(item testItemModel) types.String { return item.ContentBlocks }},
+		{Name: "role", Getter: func(item testItemModel) stringValue { return item.Role }, Required: true},
+		{Name: "content", Getter: func(item testItemModel) stringValue { return item.Content }, Required: true},
+		{Name: "call_id", Getter: func(item testItemModel) stringValue { return item.CallID }},
+		{Name: "func_name", Getter: func(item testItemModel) stringValue { return item.FuncName }},
+		{Name: "arguments", Getter: func(item testItemModel) stringValue { return item.Arguments }},
+		{Name: "output", Getter: func(item testItemModel) stringValue { return item.Output }},
+		{Name: "text", Getter: func(item testItemModel) stringValue { return item.Text }},
+		{Name: "content_blocks", Getter: func(item testItemModel) stringValue { return item.ContentBlocks }},
 	},
 	"function_call": {
-		{Name: "call_id", Getter: func(item testItemModel) types.String { return item.CallID }, Required: true},
-		{Name: "func_name", Getter: func(item testItemModel) types.String { return item.FuncName }, Required: true},
-		{Name: "arguments", Getter: func(item testItemModel) types.String { return item.Arguments }, Required: true},
-		{Name: "role", Getter: func(item testItemModel) types.String { return item.Role }},
-		{Name: "content", Getter: func(item testItemModel) types.String { return item.Content }},
-		{Name: "output", Getter: func(item testItemModel) types.String { return item.Output }},
-		{Name: "text", Getter: func(item testItemModel) types.String { return item.Text }},
-		{Name: "content_blocks", Getter: func(item testItemModel) types.String { return item.ContentBlocks }},
+		{Name: "call_id", Getter: func(item testItemModel) stringValue { return item.CallID }, Required: true},
+		{Name: "func_name", Getter: func(item testItemModel) stringValue { return item.FuncName }, Required: true},
+		{Name: "arguments", Getter: func(item testItemModel) stringValue { return item.Arguments }, Required: true},
+		{Name: "role", Getter: func(item testItemModel) stringValue { return item.Role }},
+		{Name: "content", Getter: func(item testItemModel) stringValue { return item.Content }},
+		{Name: "output", Getter: func(item testItemModel) stringValue { return item.Output }},
+		{Name: "text", Getter: func(item testItemModel) stringValue { return item.Text }},
+		{Name: "content_blocks", Getter: func(item testItemModel) stringValue { return item.ContentBlocks }},
 	},
 	"function_call_output": {
-		{Name: "call_id", Getter: func(item testItemModel) types.String { return item.CallID }, Required: true},
-		{Name: "output", Getter: func(item testItemModel) types.String { return item.Output }, Required: true},
-		{Name: "role", Getter: func(item testItemModel) types.String { return item.Role }},
-		{Name: "content", Getter: func(item testItemModel) types.String { return item.Content }},
-		{Name: "func_name", Getter: func(item testItemModel) types.String { return item.FuncName }},
-		{Name: "arguments", Getter: func(item testItemModel) types.String { return item.Arguments }},
-		{Name: "text", Getter: func(item testItemModel) types.String { return item.Text }},
-		{Name: "content_blocks", Getter: func(item testItemModel) types.String { return item.ContentBlocks }},
+		{Name: "call_id", Getter: func(item testItemModel) stringValue { return item.CallID }, Required: true},
+		{Name: "output", Getter: func(item testItemModel) stringValue { return item.Output }, Required: true},
+		{Name: "role", Getter: func(item testItemModel) stringValue { return item.Role }},
+		{Name: "content", Getter: func(item testItemModel) stringValue { return item.Content }},
+		{Name: "func_name", Getter: func(item testItemModel) stringValue { return item.FuncName }},
+		{Name: "arguments", Getter: func(item testItemModel) stringValue { return item.Arguments }},
+		{Name: "text", Getter: func(item testItemModel) stringValue { return item.Text }},
+		{Name: "content_blocks", Getter: func(item testItemModel) stringValue { return item.ContentBlocks }},
 	},
 	"anthropic_system": {
-		{Name: "role", Getter: func(item testItemModel) types.String { return item.Role }},
-		{Name: "content", Getter: func(item testItemModel) types.String { return item.Content }},
-		{Name: "call_id", Getter: func(item testItemModel) types.String { return item.CallID }},
-		{Name: "func_name", Getter: func(item testItemModel) types.String { return item.FuncName }},
-		{Name: "arguments", Getter: func(item testItemModel) types.String { return item.Arguments }},
-		{Name: "output", Getter: func(item testItemModel) types.String { return item.Output }},
+		{Name: "role", Getter: func(item testItemModel) stringValue { return item.Role }},
+		{Name: "content", Getter: func(item testItemModel) stringValue { return item.Content }},
+		{Name: "call_id", Getter: func(item testItemModel) stringValue { return item.CallID }},
+		{Name: "func_name", Getter: func(item testItemModel) stringValue { return item.FuncName }},
+		{Name: "arguments", Getter: func(item testItemModel) stringValue { return item.Arguments }},
+		{Name: "output", Getter: func(item testItemModel) stringValue { return item.Output }},
 	},
 	"anthropic_message": {
-		{Name: "role", Getter: func(item testItemModel) types.String { return item.Role }, Required: true},
-		{Name: "text", Getter: func(item testItemModel) types.String { return item.Text }},
-		{Name: "call_id", Getter: func(item testItemModel) types.String { return item.CallID }},
-		{Name: "func_name", Getter: func(item testItemModel) types.String { return item.FuncName }},
-		{Name: "arguments", Getter: func(item testItemModel) types.String { return item.Arguments }},
-		{Name: "output", Getter: func(item testItemModel) types.String { return item.Output }},
+		{Name: "role", Getter: func(item testItemModel) stringValue { return item.Role }, Required: true},
+		{Name: "text", Getter: func(item testItemModel) stringValue { return item.Text }},
+		{Name: "call_id", Getter: func(item testItemModel) stringValue { return item.CallID }},
+		{Name: "func_name", Getter: func(item testItemModel) stringValue { return item.FuncName }},
+		{Name: "arguments", Getter: func(item testItemModel) stringValue { return item.Arguments }},
+		{Name: "output", Getter: func(item testItemModel) stringValue { return item.Output }},
 	},
 }
 
@@ -195,6 +201,7 @@ func (r *testResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 						},
 						"content_blocks": schema.StringAttribute{
 							Description: "JSON-encoded array of Anthropic content blocks.",
+							CustomType:  jsontypes.NormalizedType{},
 							Optional:    true,
 						},
 						"any_role": schema.BoolAttribute{
@@ -225,6 +232,7 @@ func (r *testResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 						},
 						"arguments": schema.StringAttribute{
 							Description: "JSON-encoded arguments for function_call items.",
+							CustomType:  jsontypes.NormalizedType{},
 							Optional:    true,
 						},
 						"output": schema.StringAttribute{
@@ -500,7 +508,7 @@ func (r *testResource) ImportState(ctx context.Context, req resource.ImportState
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[2])...)
 }
 
-func validateRequiredString(diags *diag.Diagnostics, value types.String, attrPath path.Path, itemType string) {
+func validateRequiredString(diags *diag.Diagnostics, value stringValue, attrPath path.Path, itemType string) {
 	if value.IsUnknown() {
 		return
 	}
@@ -509,14 +517,14 @@ func validateRequiredString(diags *diag.Diagnostics, value types.String, attrPat
 	}
 }
 
-func validateUnexpectedString(diags *diag.Diagnostics, value types.String, attrPath path.Path, itemType string) {
+func validateUnexpectedString(diags *diag.Diagnostics, value stringValue, attrPath path.Path, itemType string) {
 	if value.IsUnknown() || value.IsNull() {
 		return
 	}
 	diags.AddAttributeError(attrPath, "Unexpected item attribute", fmt.Sprintf("%s must not be set when type is %q.", attrPath.String(), itemType))
 }
 
-func validateContentBlocks(diags *diag.Diagnostics, value types.String, attrPath path.Path) {
+func validateContentBlocks(diags *diag.Diagnostics, value stringValue, attrPath path.Path) {
 	if value.IsUnknown() || value.IsNull() {
 		return
 	}
@@ -540,35 +548,6 @@ func validateContentBlocks(diags *diag.Diagnostics, value types.String, attrPath
 			return
 		}
 	}
-}
-
-func normalizeJSON(value string) (string, error) {
-	decoder := json.NewDecoder(strings.NewReader(value))
-	decoder.UseNumber()
-	var payload interface{}
-	if err := decoder.Decode(&payload); err != nil {
-		return "", err
-	}
-	if err := decoder.Decode(&struct{}{}); err != io.EOF {
-		if err == nil {
-			return "", fmt.Errorf("unexpected trailing data")
-		}
-		return "", err
-	}
-	normalized, err := json.Marshal(payload)
-	if err != nil {
-		return "", err
-	}
-	return string(normalized), nil
-}
-
-func normalizeJSONAttr(value string, attrPath path.Path, diags *diag.Diagnostics, summary string) (string, bool) {
-	normalized, err := normalizeJSON(value)
-	if err != nil {
-		diags.AddAttributeError(attrPath, summary, fmt.Sprintf("%s must be valid JSON: %s.", attrPath.String(), err.Error()))
-		return "", false
-	}
-	return normalized, true
 }
 
 func boolPointerFromValue(value types.Bool) *bool {
@@ -605,12 +584,7 @@ func expandTestItems(items []testItemModel) ([]client.TestItem, diag.Diagnostics
 			}
 			expanded = append(expanded, messageItem)
 		case "function_call":
-			attrPath := path.Root("items").AtListIndex(index).AtName("arguments")
-			arguments, ok := normalizeJSONAttr(item.Arguments.ValueString(), attrPath, &diags, "Invalid arguments")
-			if !ok {
-				return nil, diags
-			}
-			callItem, err := client.NewFunctionCallItem(item.CallID.ValueString(), item.FuncName.ValueString(), arguments)
+			callItem, err := client.NewFunctionCallItem(item.CallID.ValueString(), item.FuncName.ValueString(), item.Arguments.ValueString())
 			if err != nil {
 				diags.AddError("Error building function_call item", err.Error())
 				return nil, diags
@@ -640,12 +614,7 @@ func expandTestItems(items []testItemModel) ([]client.TestItem, diag.Diagnostics
 			if textSet {
 				systemItem, err = client.NewAnthropicSystemTextItem(item.Text.ValueString(), anyContent)
 			} else {
-				attrPath := path.Root("items").AtListIndex(index).AtName("content_blocks")
-				blocks, ok := normalizeJSONAttr(item.ContentBlocks.ValueString(), attrPath, &diags, "Invalid content_blocks")
-				if !ok {
-					return nil, diags
-				}
-				systemItem, err = client.NewAnthropicSystemBlocksItem(json.RawMessage(blocks), anyContent)
+				systemItem, err = client.NewAnthropicSystemBlocksItem(json.RawMessage(item.ContentBlocks.ValueString()), anyContent)
 			}
 			if err != nil {
 				diags.AddError("Error building anthropic_system item", err.Error())
@@ -673,12 +642,7 @@ func expandTestItems(items []testItemModel) ([]client.TestItem, diag.Diagnostics
 			if contentSet {
 				messageItem, err = client.NewAnthropicMessageStringItem(item.Role.ValueString(), item.Content.ValueString(), anyContent)
 			} else {
-				attrPath := path.Root("items").AtListIndex(index).AtName("content_blocks")
-				blocks, ok := normalizeJSONAttr(item.ContentBlocks.ValueString(), attrPath, &diags, "Invalid content_blocks")
-				if !ok {
-					return nil, diags
-				}
-				messageItem, err = client.NewAnthropicMessageBlocksItem(item.Role.ValueString(), json.RawMessage(blocks), anyContent)
+				messageItem, err = client.NewAnthropicMessageBlocksItem(item.Role.ValueString(), json.RawMessage(item.ContentBlocks.ValueString()), anyContent)
 			}
 			if err != nil {
 				diags.AddError("Error building anthropic_message item", err.Error())
@@ -714,13 +678,13 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 				Role:          types.StringValue(messageContent.Role),
 				Content:       types.StringValue(messageContent.Content),
 				Text:          types.StringNull(),
-				ContentBlocks: types.StringNull(),
+				ContentBlocks: jsontypes.NewNormalizedNull(),
 				AnyRole:       types.BoolValue(messageContent.AnyRole),
 				AnyContent:    types.BoolValue(messageContent.AnyContent),
 				Repeat:        types.BoolValue(messageContent.Repeat),
 				CallID:        types.StringNull(),
 				FuncName:      types.StringNull(),
-				Arguments:     types.StringNull(),
+				Arguments:     jsontypes.NewNormalizedNull(),
 				Output:        types.StringNull(),
 			})
 		case "function_call":
@@ -729,23 +693,18 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 				diags.AddError("Error parsing function_call item", err.Error())
 				return nil, diags
 			}
-			normalizedArguments, err := normalizeJSON(arguments)
-			if err != nil {
-				diags.AddError("Error normalizing function_call arguments", err.Error())
-				return nil, diags
-			}
 			flattened = append(flattened, testItemModel{
 				Type:          types.StringValue("function_call"),
 				Role:          types.StringNull(),
 				Content:       types.StringNull(),
 				Text:          types.StringNull(),
-				ContentBlocks: types.StringNull(),
+				ContentBlocks: jsontypes.NewNormalizedNull(),
 				AnyRole:       types.BoolValue(false),
 				AnyContent:    types.BoolValue(false),
 				Repeat:        types.BoolValue(false),
 				CallID:        types.StringValue(callID),
 				FuncName:      types.StringValue(name),
-				Arguments:     types.StringValue(normalizedArguments),
+				Arguments:     jsontypes.NewNormalizedValue(arguments),
 				Output:        types.StringNull(),
 			})
 		case "function_call_output":
@@ -759,13 +718,13 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 				Role:          types.StringNull(),
 				Content:       types.StringNull(),
 				Text:          types.StringNull(),
-				ContentBlocks: types.StringNull(),
+				ContentBlocks: jsontypes.NewNormalizedNull(),
 				AnyRole:       types.BoolValue(false),
 				AnyContent:    types.BoolValue(false),
 				Repeat:        types.BoolValue(false),
 				CallID:        types.StringValue(callID),
 				FuncName:      types.StringNull(),
-				Arguments:     types.StringNull(),
+				Arguments:     jsontypes.NewNormalizedNull(),
 				Output:        types.StringValue(output),
 			})
 		case "anthropic_system":
@@ -775,14 +734,9 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 				return nil, diags
 			}
 			textValue := types.StringNull()
-			blocksValue := types.StringNull()
+			blocksValue := jsontypes.NewNormalizedNull()
 			if systemContent.Blocks != nil {
-				blocks, err := normalizeJSON(string(systemContent.Blocks))
-				if err != nil {
-					diags.AddError("Error normalizing anthropic_system content_blocks", err.Error())
-					return nil, diags
-				}
-				blocksValue = types.StringValue(blocks)
+				blocksValue = jsontypes.NewNormalizedValue(string(systemContent.Blocks))
 			} else {
 				textValue = types.StringValue(systemContent.Text)
 			}
@@ -797,7 +751,7 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 				Repeat:        types.BoolValue(false),
 				CallID:        types.StringNull(),
 				FuncName:      types.StringNull(),
-				Arguments:     types.StringNull(),
+				Arguments:     jsontypes.NewNormalizedNull(),
 				Output:        types.StringNull(),
 			})
 		case "anthropic_message":
@@ -807,14 +761,9 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 				return nil, diags
 			}
 			contentValue := types.StringNull()
-			blocksValue := types.StringNull()
+			blocksValue := jsontypes.NewNormalizedNull()
 			if messageContent.ContentBlocks != nil {
-				blocks, err := normalizeJSON(string(messageContent.ContentBlocks))
-				if err != nil {
-					diags.AddError("Error normalizing anthropic_message content_blocks", err.Error())
-					return nil, diags
-				}
-				blocksValue = types.StringValue(blocks)
+				blocksValue = jsontypes.NewNormalizedValue(string(messageContent.ContentBlocks))
 			} else {
 				contentValue = types.StringValue(messageContent.Content)
 			}
@@ -829,7 +778,7 @@ func flattenTestItems(items []client.TestItem) ([]testItemModel, diag.Diagnostic
 				Repeat:        types.BoolValue(false),
 				CallID:        types.StringNull(),
 				FuncName:      types.StringNull(),
-				Arguments:     types.StringNull(),
+				Arguments:     jsontypes.NewNormalizedNull(),
 				Output:        types.StringNull(),
 			})
 		default:

--- a/internal/provider/test_resource_normalization_test.go
+++ b/internal/provider/test_resource_normalization_test.go
@@ -1,94 +1,46 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/agynio/terraform-provider-testllm/internal/client"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func TestNormalizeJSON(t *testing.T) {
-	t.Run("sorts keys", func(t *testing.T) {
-		normalized, err := normalizeJSON(`{"z":1,"a":2}`)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if normalized != `{"a":2,"z":1}` {
-			t.Fatalf("expected normalized JSON, got %q", normalized)
-		}
-	})
-
-	t.Run("idempotent", func(t *testing.T) {
-		input := `{"a":2,"z":1}`
-		normalized, err := normalizeJSON(input)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if normalized != input {
-			t.Fatalf("expected %q, got %q", input, normalized)
-		}
-	})
-
-	t.Run("invalid JSON", func(t *testing.T) {
-		if _, err := normalizeJSON(`{"a":}`); err == nil {
-			t.Fatalf("expected error for invalid JSON")
-		}
-	})
-
-	t.Run("trailing data", func(t *testing.T) {
-		if _, err := normalizeJSON(`{"a":1} {"b":2}`); err == nil {
-			t.Fatalf("expected trailing data error")
-		} else if !strings.Contains(err.Error(), "unexpected trailing data") {
-			t.Fatalf("expected trailing data error, got %v", err)
-		}
-	})
-
-	t.Run("numeric precision", func(t *testing.T) {
-		normalized, err := normalizeJSON(`{"big":9007199254740993}`)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if normalized != `{"big":9007199254740993}` {
-			t.Fatalf("expected precision preserved, got %q", normalized)
-		}
-	})
-
-	t.Run("empty string", func(t *testing.T) {
-		if _, err := normalizeJSON(""); err == nil {
-			t.Fatalf("expected error for empty string")
-		}
-	})
-
-	t.Run("whitespace string", func(t *testing.T) {
-		if _, err := normalizeJSON(" \n\t "); err == nil {
-			t.Fatalf("expected error for whitespace string")
-		}
-	})
+func assertJSONSemanticallyEqual(t *testing.T, expected, actual string) {
+	t.Helper()
+	match, diags := jsontypes.NewNormalizedValue(expected).StringSemanticEquals(
+		context.Background(),
+		jsontypes.NewNormalizedValue(actual),
+	)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !match {
+		t.Fatalf("expected JSON %q to equal %q", expected, actual)
+	}
 }
 
-func TestExpandTestItems_normalizesJSON(t *testing.T) {
-	arguments := `{"z":1,"a":2}`
-	blocks := `[
-  {"type":"tool_use","id":"tool-1","name":"get_weather","input":{"z":1,"a":2}}
-]`
-	systemBlocks := `[
-  {"text":"Welcome","type":"text","meta":{"z":1,"a":2}}
-]`
+func TestExpandTestItems_preservesJSON(t *testing.T) {
+	arguments := `{"command": "agyn threads send --message \"Thinking\" > /dev/null && echo ok", "meta": {"z": 1, "a": 2}}`
+	blocks := `[ { "type": "text", "text": "Use > /dev/null && echo ok" } ]`
+	systemBlocks := `[{"type": "text", "text": "System > /dev/null && echo ok"}]`
 	items := []testItemModel{
 		{
 			Type:          types.StringValue("function_call"),
 			Role:          types.StringNull(),
 			Content:       types.StringNull(),
 			Text:          types.StringNull(),
-			ContentBlocks: types.StringNull(),
+			ContentBlocks: jsontypes.NewNormalizedNull(),
 			AnyRole:       types.BoolValue(false),
 			AnyContent:    types.BoolValue(false),
 			Repeat:        types.BoolValue(false),
 			CallID:        types.StringValue("call-1"),
 			FuncName:      types.StringValue("get_data"),
-			Arguments:     types.StringValue(arguments),
+			Arguments:     jsontypes.NewNormalizedValue(arguments),
 			Output:        types.StringNull(),
 		},
 		{
@@ -96,13 +48,13 @@ func TestExpandTestItems_normalizesJSON(t *testing.T) {
 			Role:          types.StringValue("assistant"),
 			Content:       types.StringNull(),
 			Text:          types.StringNull(),
-			ContentBlocks: types.StringValue(blocks),
+			ContentBlocks: jsontypes.NewNormalizedValue(blocks),
 			AnyRole:       types.BoolValue(false),
 			AnyContent:    types.BoolValue(false),
 			Repeat:        types.BoolValue(false),
 			CallID:        types.StringNull(),
 			FuncName:      types.StringNull(),
-			Arguments:     types.StringNull(),
+			Arguments:     jsontypes.NewNormalizedNull(),
 			Output:        types.StringNull(),
 		},
 		{
@@ -110,13 +62,13 @@ func TestExpandTestItems_normalizesJSON(t *testing.T) {
 			Role:          types.StringNull(),
 			Content:       types.StringNull(),
 			Text:          types.StringNull(),
-			ContentBlocks: types.StringValue(systemBlocks),
+			ContentBlocks: jsontypes.NewNormalizedValue(systemBlocks),
 			AnyRole:       types.BoolValue(false),
 			AnyContent:    types.BoolValue(false),
 			Repeat:        types.BoolValue(false),
 			CallID:        types.StringNull(),
 			FuncName:      types.StringNull(),
-			Arguments:     types.StringNull(),
+			Arguments:     jsontypes.NewNormalizedNull(),
 			Output:        types.StringNull(),
 		},
 	}
@@ -129,12 +81,12 @@ func TestExpandTestItems_normalizesJSON(t *testing.T) {
 		t.Fatalf("expected 3 items, got %d", len(expanded))
 	}
 
-	_, _, normalizedArgs, err := client.ParseFunctionCallContent(expanded[0])
+	_, _, expandedArgs, err := client.ParseFunctionCallContent(expanded[0])
 	if err != nil {
 		t.Fatalf("parse function_call item: %v", err)
 	}
-	if normalizedArgs != `{"a":2,"z":1}` {
-		t.Fatalf("expected normalized arguments, got %q", normalizedArgs)
+	if expandedArgs != arguments {
+		t.Fatalf("expected arguments %q, got %q", arguments, expandedArgs)
 	}
 
 	messageContent, err := client.ParseAnthropicMessageContent(expanded[1])
@@ -144,9 +96,7 @@ func TestExpandTestItems_normalizesJSON(t *testing.T) {
 	if messageContent.ContentBlocks == nil {
 		t.Fatalf("expected content blocks to be set")
 	}
-	if string(messageContent.ContentBlocks) != `[{"id":"tool-1","input":{"a":2,"z":1},"name":"get_weather","type":"tool_use"}]` {
-		t.Fatalf("expected normalized content blocks, got %s", messageContent.ContentBlocks)
-	}
+	assertJSONSemanticallyEqual(t, blocks, string(messageContent.ContentBlocks))
 
 	systemContent, err := client.ParseAnthropicSystemContent(expanded[2])
 	if err != nil {
@@ -155,25 +105,23 @@ func TestExpandTestItems_normalizesJSON(t *testing.T) {
 	if systemContent.Blocks == nil {
 		t.Fatalf("expected system content blocks to be set")
 	}
-	if string(systemContent.Blocks) != `[{"meta":{"a":2,"z":1},"text":"Welcome","type":"text"}]` {
-		t.Fatalf("expected normalized system blocks, got %s", systemContent.Blocks)
-	}
+	assertJSONSemanticallyEqual(t, systemBlocks, string(systemContent.Blocks))
 }
 
-func TestFlattenTestItems_normalizesJSON(t *testing.T) {
-	arguments := `{"z":1,"a":2}`
+func TestFlattenTestItems_preservesJSON(t *testing.T) {
+	arguments := `{"command": "agyn threads send --message \"Thinking\" > /dev/null && echo ok", "meta": {"z": 1, "a": 2}}`
 	callItem, err := client.NewFunctionCallItem("call-1", "get_data", arguments)
 	if err != nil {
 		t.Fatalf("build function_call item: %v", err)
 	}
 
-	blocks := json.RawMessage(`[{"type":"tool_use","id":"tool-1","name":"get_weather","input":{"z":1,"a":2}}]`)
+	blocks := json.RawMessage(`[ { "type": "text", "text": "Use > /dev/null && echo ok" } ]`)
 	messageItem, err := client.NewAnthropicMessageBlocksItem("assistant", blocks, nil)
 	if err != nil {
 		t.Fatalf("build anthropic_message item: %v", err)
 	}
 
-	systemBlocks := json.RawMessage(`[{"text":"Welcome","type":"text","meta":{"z":1,"a":2}}]`)
+	systemBlocks := json.RawMessage(`[{"type": "text", "text": "System > /dev/null && echo ok"}]`)
 	systemItem, err := client.NewAnthropicSystemBlocksItem(systemBlocks, nil)
 	if err != nil {
 		t.Fatalf("build anthropic_system item: %v", err)
@@ -187,13 +135,9 @@ func TestFlattenTestItems_normalizesJSON(t *testing.T) {
 		t.Fatalf("expected 3 items, got %d", len(flattened))
 	}
 
-	if flattened[0].Arguments.ValueString() != `{"a":2,"z":1}` {
-		t.Fatalf("expected normalized arguments, got %q", flattened[0].Arguments.ValueString())
+	if flattened[0].Arguments.ValueString() != arguments {
+		t.Fatalf("expected arguments %q, got %q", arguments, flattened[0].Arguments.ValueString())
 	}
-	if flattened[1].ContentBlocks.ValueString() != `[{"id":"tool-1","input":{"a":2,"z":1},"name":"get_weather","type":"tool_use"}]` {
-		t.Fatalf("expected normalized content blocks, got %q", flattened[1].ContentBlocks.ValueString())
-	}
-	if flattened[2].ContentBlocks.ValueString() != `[{"meta":{"a":2,"z":1},"text":"Welcome","type":"text"}]` {
-		t.Fatalf("expected normalized system blocks, got %q", flattened[2].ContentBlocks.ValueString())
-	}
+	assertJSONSemanticallyEqual(t, string(blocks), flattened[1].ContentBlocks.ValueString())
+	assertJSONSemanticallyEqual(t, string(systemBlocks), flattened[2].ContentBlocks.ValueString())
 }

--- a/internal/provider/test_resource_test.go
+++ b/internal/provider/test_resource_test.go
@@ -81,7 +81,7 @@ func TestAccTestResource_functionCallItems(t *testing.T) {
     type      = "function_call"
     call_id   = "call-1"
     func_name = "get_data"
-    arguments = jsonencode({ foo = "bar" })
+    arguments = "{\"command\": \"agyn threads send --message \\\"Thinking\\\" > /dev/null && echo ok\"}"
   },
   {
     type    = "function_call_output"
@@ -204,7 +204,7 @@ func TestAccTestResource_anthropicToolUse(t *testing.T) {
 	items := `[
   {
     type           = "anthropic_system"
-    content_blocks = jsonencode([{ type = "text", text = "Use tools when needed." }])
+    content_blocks = "[{ \"type\": \"text\", \"text\": \"Use tools when needed > /dev/null && echo ok\" }]"
   },
   {
     type    = "anthropic_message"


### PR DESCRIPTION
## Summary
- switch test item JSON fields to jsontypes.Normalized for semantic equality
- remove manual JSON normalization logic and update expand/flatten paths
- add unit/acceptance coverage for literal JSON strings with plan-only checks

## Testing
- go test ./...
- go vet ./...

Closes #17